### PR TITLE
Do not build binary in install.sh

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,6 @@ archives:
       {{ .ProjectName }}_{{ .Version}}_{{ .Os }}_{{ .Arch }}
     files:
       - LICENSE
-      - README.md
-      - config.yaml.example
-      - nannyagent.service
       - install.sh
 
 checksum:


### PR DESCRIPTION
- Do not build binary in install.sh (only pre-built binaries should be downloaded)
- Do not package README.md, config.yaml.example & nannyagent.service (They are part of install.sh except README.md)