### PR TITLE
Consume static token

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,6 +14,28 @@ portal_url: "https://nannyai.dev"
 # Default: /var/lib/nannyagent/token.json
 token_path: "/var/lib/nannyagent/token.json"
 
+# ─── Static Token Authentication (alternative to OAuth2) ────────────────────
+#
+# Static tokens bypass the entire OAuth2 device flow. When set, the agent uses
+# this token directly as a Bearer credential on every API request, with no
+# access token refresh or renewal needed.
+#
+# How to use:
+#   1. Create a static token in the NannyAI portal (or via API)
+#   2. Set it here (must start with nsk_)
+#   3. Run: sudo nannyagent --register
+#      The agent will auto-register without user interaction
+#   4. Start the agent normally: sudo systemctl enable --now nannyagent
+#
+# The token can also be set via NANNYAI_STATIC_TOKEN environment variable.
+# Static tokens are NOT exposed as CLI arguments for security (process list).
+#
+# static_token: "nsk_your_static_token_here"
+
+# Agent ID (auto-populated after registration, do not set manually unless
+# you know the agent ID from a previous registration)
+# agent_id: ""
+
 # Node metrics collection interval in seconds (optional)
 # Default: 30
 metrics_interval: 30

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -223,6 +223,45 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 Content-Type: application/json
 ```
 
+### Static Token Authentication (alternative)
+
+Static tokens (`nsk_*`) bypass the device auth flow entirely. The agent sends a
+single registration request and subsequently authenticates all API calls with the
+static token.
+
+**Registration (no device auth):**
+
+```bash
+curl -X POST https://api.nannyai.dev/api/agent \
+  -H "Authorization: Bearer nsk_your_static_token" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "register-with-token",
+    "hostname": "prod-web-01",
+    "os_type": "linux",
+    "platform_family": "debian",
+    "version": "0.0.15",
+    "primary_ip": "10.0.1.5",
+    "kernel_version": "5.15.0-56-generic",
+    "all_ips": ["10.0.1.5", "172.17.0.1"]
+  }'
+```
+
+**Response:**
+```json
+{
+  "agent_id": "aqvdtvpuoyvji6t"
+}
+```
+
+**Subsequent authenticated requests:**
+
+```http
+Authorization: Bearer nsk_your_static_token
+X-Agent-ID: aqvdtvpuoyvji6t
+Content-Type: application/json
+```
+
 ## REST API Endpoints
 
 ### Health Check

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -280,7 +280,7 @@ ls -la /etc/nannyagent/config.yaml
 
 ## Environment Variables
 
-Environment variables have **highest priority** and override values from `/etc/nannyagent/config.yaml`.
+Environment variables override values from `/etc/nannyagent/config.yaml`, but are themselves overridden by command-line arguments (see [Command-Line Arguments](#command-line-arguments)).
 
 ### Supported Variables
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,6 +9,8 @@
 
 - [Overview](#overview)
 - [Configuration Priority](#configuration-priority)
+- [Authentication Modes](#authentication-modes)
+- [Command-Line Arguments](#command-line-arguments)
 - [Configuration File](#configuration-file)
 - [Environment Variables](#environment-variables)
 - [Configuration Options](#configuration-options)
@@ -18,10 +20,11 @@
 
 ## Overview
 
-NannyAgent uses a simple, secure configuration system with two sources:
+NannyAgent uses a simple, secure configuration system with three sources:
 
 1. **YAML configuration file**: `/etc/nannyagent/config.yaml`
 2. **Environment variables**: Override YAML settings
+3. **Command-line arguments**: Highest priority, override both YAML and env vars
 
 This design provides flexibility for different deployment scenarios while maintaining security.
 
@@ -30,9 +33,98 @@ This design provides flexibility for different deployment scenarios while mainta
 Configuration is loaded in the following order (later sources override earlier):
 
 1. `/etc/nannyagent/config.yaml` (system-wide YAML config)
-2. Environment variables (highest priority - overrides YAML)
+2. Environment variables (override YAML)
+3. Command-line arguments (highest priority - override everything)
 
-**That's it!** There are no `.env` files, no local config files, no other configuration locations.
+## Authentication Modes
+
+NannyAgent supports two authentication modes:
+
+### OAuth2 Device Flow (default)
+
+The traditional interactive registration flow. Requires a user to approve the agent
+in the NannyAI portal.
+
+```bash
+sudo nannyagent --register
+# Follow the portal instructions to enter the user code
+```
+
+### Static Token (automated, no user interaction)
+
+Static tokens bypass the entire OAuth2 flow. The agent auto-registers using the
+static token as a user credential. Ideal for automation and fleet deployment.
+
+**Setup:**
+
+1. Create a static token in the NannyAI portal (or via API `create-static-token`)
+2. Add it to `/etc/nannyagent/config.yaml`:
+   ```yaml
+   nannyapi_url: "https://api.nannyai.dev"
+   static_token: "nsk_your_token_here"
+   ```
+3. Register the agent (fully automated, no portal interaction):
+   ```bash
+   sudo nannyagent --register
+   ```
+4. Start the service:
+   ```bash
+   sudo systemctl enable --now nannyagent
+   ```
+
+**How it works:**
+
+- The static token (prefixed `nsk_`) is sent as `Authorization: Bearer nsk_...`
+- An `X-Agent-ID` header identifies the specific agent
+- No access token refresh or renewal is needed — the static token is long-lived
+- The `agent_id` is auto-saved to `/etc/nannyagent/config.yaml` after registration
+
+**Environment variable alternative:**
+
+```bash
+export NANNYAI_STATIC_TOKEN=nsk_your_token_here
+```
+
+> **Security:** The `static_token` is intentionally NOT available as a CLI argument
+> to prevent exposure in the process list. Use the config file or env var only.
+
+## Command-Line Arguments
+
+All YAML configuration options are available as CLI flags with the highest priority.
+
+| Flag | YAML Key | Description |
+|------|----------|-------------|
+| `--api-url <url>` | `nannyapi_url` | NannyAPI endpoint URL |
+| `--portal-url <url>` | `portal_url` | Portal URL for device auth |
+| `--token-path <path>` | `token_path` | Token storage path |
+| `--metrics-interval <secs>` | `metrics_interval` | Metrics collection interval |
+| `--proxmox-interval <secs>` | `proxmox_interval` | Proxmox data collection interval |
+| `--agent-id <id>` | `agent_id` | Agent ID (static token mode) |
+| `--debug` | `debug` | Enable debug mode |
+
+**Commands:**
+
+| Flag | Description |
+|------|-------------|
+| `--register` | Register agent (interactive or automated with static token) |
+| `--status` | Show agent status and connectivity |
+| `--diagnose <issue>` | Run one-off diagnosis |
+| `--daemon` | Run as daemon (systemd mode) |
+| `--version` | Show version |
+| `--help` | Show help |
+
+**Examples:**
+
+```bash
+# Register with a specific API URL
+sudo nannyagent --register --api-url http://localhost:8090
+
+# Run in debug mode with custom metrics interval
+sudo nannyagent --daemon --debug --metrics-interval 60
+
+# One-off diagnosis with custom API URL
+sudo nannyagent --diagnose "disk full on /var" --api-url http://my-api:8090
+```
 
 ## Configuration File
 
@@ -55,6 +147,12 @@ portal_url: https://nannyai.dev
 
 # Optional: Token storage path (default: /var/lib/nannyagent/token.json)
 token_path: /var/lib/nannyagent/token.json
+
+# Optional: Static token for automated auth (bypasses OAuth2)
+# static_token: "nsk_your_static_token_here"
+
+# Optional: Agent ID (auto-populated after registration)
+# agent_id: ""
 
 # Optional: Metrics collection interval in seconds (default: 30)
 metrics_interval: 30
@@ -121,6 +219,8 @@ Environment variables have **highest priority** and override values from `/etc/n
 | `NANNYAPI_URL` | string | **(required)** | NannyAPI backend URL |
 | `NANNYAI_PORTAL_URL` | string | `https://nannyai.dev` | Portal URL for device auth |
 | `TOKEN_PATH` | string | `/var/lib/nannyagent/token.json` | Token storage location |
+| `NANNYAI_STATIC_TOKEN` | string | *(empty)* | Static API token (nsk_...) |
+| `NANNYAI_AGENT_ID` | string | *(empty)* | Agent ID for static token mode |
 | `DEBUG` | bool | `false` | Enable debug logging (`true` or `1`) |
 
 ### Using Environment Variables

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,6 +11,7 @@
 - [Configuration Priority](#configuration-priority)
 - [Authentication Modes](#authentication-modes)
 - [Command-Line Arguments](#command-line-arguments)
+- [Validation Rules](#validation-rules)
 - [Configuration File](#configuration-file)
 - [Environment Variables](#environment-variables)
 - [Configuration Options](#configuration-options)
@@ -74,8 +75,11 @@ static token as a user credential. Ideal for automation and fleet deployment.
 
 **How it works:**
 
+- Registration sends a single `POST /api/agent` with `action: "register-with-token"`
+  and system information (hostname, OS, IPs, kernel version)
 - The static token (prefixed `nsk_`) is sent as `Authorization: Bearer nsk_...`
-- An `X-Agent-ID` header identifies the specific agent
+- No device authorization flow is triggered — no device codes, user codes, or polling
+- An `X-Agent-ID` header identifies the specific agent after registration
 - No access token refresh or renewal is needed — the static token is long-lived
 - The `agent_id` is auto-saved to `/etc/nannyagent/config.yaml` after registration
 
@@ -125,6 +129,72 @@ sudo nannyagent --daemon --debug --metrics-interval 60
 # One-off diagnosis with custom API URL
 sudo nannyagent --diagnose "disk full on /var" --api-url http://my-api:8090
 ```
+
+## Validation Rules
+
+All configuration values are validated regardless of source (YAML, environment
+variable, or CLI flag). Validation runs twice: once after loading config + env,
+and again after CLI flags are merged. Invalid values cause an immediate, clear
+error message and the agent will not start.
+
+### URLs (`nannyapi_url`, `portal_url`)
+
+| Rule | Detail |
+|------|--------|
+| Scheme | Must be `http` or `https` |
+| Host | Must be present (e.g. `https://` alone is rejected) |
+| Length | Max 2 048 characters |
+| Format | Must be a parseable URL |
+
+### Intervals (`metrics_interval`, `proxmox_interval`)
+
+| Rule | Detail |
+|------|--------|
+| Minimum | 5 seconds |
+| Maximum | 604 800 seconds (7 days) |
+| Negative / zero | Rejected |
+
+### Token Path (`token_path`)
+
+| Rule | Detail |
+|------|--------|
+| Path type | Must be an absolute path (starts with `/`) |
+| Length | Max 4 096 characters |
+
+### Static Token (`static_token`)
+
+| Rule | Detail |
+|------|--------|
+| Prefix | Must start with `nsk_` |
+| Min length | 5 characters (`nsk_` + at least 1) |
+| Max length | 512 characters |
+
+### Agent ID (`agent_id`)
+
+| Rule | Detail |
+|------|--------|
+| Whitespace | Must not be blank / whitespace-only |
+| Max length | 256 characters |
+
+### Token Renewal
+
+| Setting | Min | Max |
+|---------|-----|-----|
+| `token_renewal_threshold_days` | 1 | 365 |
+| `token_renewal_check_interval_secs` | 1 | 2 592 000 (30 days) |
+| `token_renewal_retry_interval_secs` | 1 | 2 592 000 (30 days) |
+
+### HTTP Transport
+
+| Setting | Min | Max |
+|---------|-----|-----|
+| `max_idle_conns` | 0 | 1 000 |
+| `max_idle_conns_per_host` | 0 | 1 000 (and ≤ `max_idle_conns`) |
+| `idle_conn_timeout_sec` | 0 | 3 600 (1 hour) |
+| `response_header_timeout_sec` | 0 | 300 (5 minutes) |
+| `transport_reset_threshold` | 1 | 100 |
+| `initial_retry_delay_sec` | 1 | 86 400 (1 day) |
+| `max_retry_delay_sec` | 1 | 86 400 (and ≥ `initial_retry_delay_sec`) |
 
 ## Configuration File
 

--- a/internal/auth/static_token.go
+++ b/internal/auth/static_token.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -366,8 +365,14 @@ func (sm *StaticTokenAuthManager) calculateBackoff() time.Duration {
 		return maxDelay
 	}
 
-	backoff := initialDelay * time.Duration(math.Pow(2, float64(attempts)))
-	if backoff > maxDelay || backoff <= 0 {
+	// Use integer shift to avoid float64 overflow in math.Pow.
+	// Clamp to maxDelay before multiplication to prevent time.Duration overflow.
+	shift := time.Duration(1) << uint(attempts)
+	if shift <= 0 || initialDelay > maxDelay/shift {
+		return maxDelay
+	}
+	backoff := initialDelay * shift
+	if backoff > maxDelay {
 		backoff = maxDelay
 	}
 	return backoff

--- a/internal/auth/static_token.go
+++ b/internal/auth/static_token.go
@@ -2,12 +2,17 @@ package auth
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
+
+	"github.com/shirou/gopsutil/v3/host"
 
 	"nannyagent/internal/config"
 	"nannyagent/internal/logging"
@@ -84,6 +89,150 @@ func (sm *StaticTokenAuthManager) EnsureAuthenticated() error {
 		return fmt.Errorf("static token not configured")
 	}
 	return nil
+}
+
+// staticRegisterRequest is the payload sent to the backend when registering
+// an agent via static token.  Uses action "register-with-token" and includes
+// system information — no device_code involved.
+type staticRegisterRequest struct {
+	Action         string   `json:"action"`
+	Hostname       string   `json:"hostname"`
+	OSType         string   `json:"os_type"`
+	PlatformFamily string   `json:"platform_family"`
+	Version        string   `json:"version"`
+	PrimaryIP      string   `json:"primary_ip"`
+	KernelVersion  string   `json:"kernel_version"`
+	AllIPs         []string `json:"all_ips"`
+}
+
+// StaticRegisterResponse is the response from a static-token registration.
+type StaticRegisterResponse struct {
+	AgentID          string `json:"agent_id,omitempty"`
+	Error            string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// Register performs a direct agent registration using the static token.
+// It does NOT start a device authorization flow — instead it sends a single
+// POST /api/agent { action: "register-with-token" } with the static token
+// Authorization header.  The backend creates the agent and returns an agent_id.
+func (sm *StaticTokenAuthManager) Register(version string) (*StaticRegisterResponse, error) {
+	primaryIP, allIPs := staticGetIPs()
+
+	payload := staticRegisterRequest{
+		Action:         "register-with-token",
+		Hostname:       staticGetHostname(),
+		OSType:         staticGetPlatform(),
+		PlatformFamily: staticGetPlatformFamily(),
+		Version:        version,
+		PrimaryIP:      primaryIP,
+		KernelVersion:  staticGetKernelVersion(),
+		AllIPs:         allIPs,
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal register request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/agent", sm.baseURL)
+	statusCode, body, err := sm.AuthenticatedRequest("POST", url, jsonData, nil)
+	if err != nil {
+		return nil, fmt.Errorf("registration request failed: %w", err)
+	}
+
+	var resp StaticRegisterResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse registration response (status %d): %w", statusCode, err)
+	}
+
+	if resp.Error != "" {
+		return nil, fmt.Errorf("registration failed: %s — %s", resp.Error, resp.ErrorDescription)
+	}
+
+	if resp.AgentID == "" {
+		return nil, fmt.Errorf("registration response missing agent_id (status %d)", statusCode)
+	}
+
+	return &resp, nil
+}
+
+// ── System-info helpers (package-level, mirror the ones in auth.go) ────────
+
+func staticGetHostname() string {
+	if hostname, err := os.Hostname(); err == nil {
+		return hostname
+	}
+	return "unknown"
+}
+
+func staticGetPlatform() string {
+	platform := os.Getenv("GOOS")
+	if platform == "" {
+		platform = "linux"
+	}
+	return platform
+}
+
+func staticGetPlatformFamily() string {
+	platform, family, _, err := host.PlatformInformation()
+	if err != nil {
+		return "unknown"
+	}
+	if family == "" {
+		return platform
+	}
+	return family
+}
+
+func staticGetKernelVersion() string {
+	version, err := host.KernelVersion()
+	if err != nil {
+		return "unknown"
+	}
+	return version
+}
+
+// staticGetIPs returns the primary non-loopback IP and a list of all IPs.
+func staticGetIPs() (string, []string) {
+	var primaryIP string
+	var allIPs []string
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "unknown", nil
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			allIPs = append(allIPs, ip.String())
+			if primaryIP == "" && ip.To4() != nil {
+				primaryIP = ip.String()
+			}
+		}
+	}
+
+	if primaryIP == "" {
+		primaryIP = "unknown"
+	}
+	return primaryIP, allIPs
 }
 
 // AuthenticatedRequest performs an HTTP request with the static token and

--- a/internal/auth/static_token.go
+++ b/internal/auth/static_token.go
@@ -1,0 +1,282 @@
+package auth
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"sync"
+	"time"
+
+	"nannyagent/internal/config"
+	"nannyagent/internal/logging"
+)
+
+// StaticTokenAuthManager handles authentication using a static API token (nsk_*).
+// It bypasses the entire OAuth2 device flow, token refresh, and token renewal.
+// The static token is sent as a Bearer credential on every request, and an
+// X-Agent-ID header identifies the target agent.
+type StaticTokenAuthManager struct {
+	config    *config.Config
+	client    *http.Client
+	transport *http.Transport
+	mu        sync.RWMutex
+	baseURL   string
+	agentID   string
+	token     string
+
+	// Connection error tracking (same pattern as AuthManager)
+	consecutiveConnErrors int
+	retryAttempts         int
+}
+
+// NewStaticTokenAuthManager creates a new static token auth manager.
+func NewStaticTokenAuthManager(cfg *config.Config) *StaticTokenAuthManager {
+	baseURL := cfg.APIBaseURL
+	transport := createTransport(cfg)
+
+	return &StaticTokenAuthManager{
+		config:    cfg,
+		baseURL:   baseURL,
+		agentID:   cfg.AgentID,
+		token:     cfg.StaticToken,
+		transport: transport,
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   5 * time.Minute,
+		},
+	}
+}
+
+// SetAgentID sets the agent ID (called after registration).
+func (sm *StaticTokenAuthManager) SetAgentID(id string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.agentID = id
+}
+
+// GetCurrentAgentID returns the configured agent ID.
+func (sm *StaticTokenAuthManager) GetCurrentAgentID() (string, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if sm.agentID == "" {
+		return "", fmt.Errorf("agent_id not configured; run --register first")
+	}
+	return sm.agentID, nil
+}
+
+// GetCurrentAccessToken returns the static token. This satisfies the
+// realtime.TokenProvider interface so SSE connections work with static tokens.
+func (sm *StaticTokenAuthManager) GetCurrentAccessToken() (string, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	if sm.token == "" {
+		return "", fmt.Errorf("static token not configured")
+	}
+	return sm.token, nil
+}
+
+// EnsureAuthenticated is a no-op for static tokens (always authenticated).
+// Returns nil token since static token mode doesn't use AuthToken structs.
+func (sm *StaticTokenAuthManager) EnsureAuthenticated() error {
+	if sm.token == "" {
+		return fmt.Errorf("static token not configured")
+	}
+	return nil
+}
+
+// AuthenticatedRequest performs an HTTP request with the static token and
+// X-Agent-ID header. Retries indefinitely on connection errors with
+// exponential backoff (same resilience as OAuth AuthManager).
+func (sm *StaticTokenAuthManager) AuthenticatedRequest(method, url string, body []byte, headers map[string]string) (int, []byte, error) {
+	for {
+		resp, err := sm.AuthenticatedDo(method, url, body, headers)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		statusCode := resp.StatusCode
+		respBody, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if readErr == nil {
+			sm.clearConnErrors()
+			sm.resetRetryAttempts()
+			return statusCode, respBody, nil
+		}
+
+		// Body read failed — retry with backoff
+		if isConnectionError(readErr) {
+			if sm.recordConnError() {
+				logging.Info("Static token: transport reset triggered by read error: %v", readErr)
+			}
+			backoff := sm.calculateBackoff()
+			sm.incrementRetryAttempts()
+			logging.Warning("Static token: read error: %v. Retrying in %v", readErr, backoff)
+			time.Sleep(backoff)
+			continue
+		}
+
+		backoff := sm.calculateBackoff()
+		sm.incrementRetryAttempts()
+		logging.Warning("Static token: read error: %v. Retrying in %v", readErr, backoff)
+		sm.getClient().CloseIdleConnections()
+		time.Sleep(backoff)
+	}
+}
+
+// AuthenticatedDo performs an HTTP request with static token auth and infinite
+// retry on connection/server errors. Returns the http.Response for callers that
+// need streaming or custom body handling.
+func (sm *StaticTokenAuthManager) AuthenticatedDo(method, url string, body []byte, headers map[string]string) (*http.Response, error) {
+	for {
+		req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		// Set default content type if not provided
+		if headers == nil || headers["Content-Type"] == "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+
+		// Static token auth
+		req.Header.Set("Authorization", "Bearer "+sm.token)
+
+		// X-Agent-ID to act as the specific agent
+		sm.mu.RLock()
+		agentID := sm.agentID
+		sm.mu.RUnlock()
+		if agentID != "" {
+			req.Header.Set("X-Agent-ID", agentID)
+		}
+
+		client := sm.getClient()
+		resp, err := client.Do(req)
+		if err != nil {
+			if isConnectionError(err) {
+				if sm.recordConnError() {
+					logging.Info("Static token: transport reset after connection error: %v", err)
+				}
+				backoff := sm.calculateBackoff()
+				sm.incrementRetryAttempts()
+				logging.Warning("Static token: connection error: %v. Retrying in %v (will never give up)", err, backoff)
+				time.Sleep(backoff)
+				continue
+			}
+
+			backoff := sm.calculateBackoff()
+			sm.incrementRetryAttempts()
+			logging.Warning("Static token: request error: %v. Retrying in %v", err, backoff)
+			client.CloseIdleConnections()
+			time.Sleep(backoff)
+			continue
+		}
+
+		sm.clearConnErrors()
+		sm.resetRetryAttempts()
+
+		// 401/403 with static token is fatal — don't retry
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return resp, nil
+		}
+
+		// 5xx — retry with backoff
+		if resp.StatusCode >= 500 {
+			_ = resp.Body.Close()
+			backoff := sm.calculateBackoff()
+			sm.incrementRetryAttempts()
+			logging.Warning("Static token: server error %d. Retrying in %v", resp.StatusCode, backoff)
+			time.Sleep(backoff)
+			continue
+		}
+
+		return resp, nil
+	}
+}
+
+// ── Connection error tracking (mirrors AuthManager) ────────────────────────
+
+func (sm *StaticTokenAuthManager) calculateBackoff() time.Duration {
+	sm.mu.RLock()
+	attempts := sm.retryAttempts
+	tc := sm.config.HTTPTransport
+	sm.mu.RUnlock()
+
+	initialDelay := time.Duration(tc.InitialRetryDelaySec) * time.Second
+	maxDelay := time.Duration(tc.MaxRetryDelaySec) * time.Second
+
+	if attempts <= 0 {
+		return initialDelay
+	}
+	if attempts > 30 {
+		return maxDelay
+	}
+
+	backoff := initialDelay * time.Duration(math.Pow(2, float64(attempts)))
+	if backoff > maxDelay || backoff <= 0 {
+		backoff = maxDelay
+	}
+	return backoff
+}
+
+func (sm *StaticTokenAuthManager) incrementRetryAttempts() {
+	sm.mu.Lock()
+	sm.retryAttempts++
+	sm.mu.Unlock()
+}
+
+func (sm *StaticTokenAuthManager) resetRetryAttempts() {
+	sm.mu.Lock()
+	sm.retryAttempts = 0
+	sm.mu.Unlock()
+}
+
+func (sm *StaticTokenAuthManager) recordConnError() bool {
+	sm.mu.Lock()
+	sm.consecutiveConnErrors++
+	threshold := sm.config.HTTPTransport.TransportResetThreshold
+	shouldReset := sm.consecutiveConnErrors >= threshold
+	sm.mu.Unlock()
+
+	if shouldReset {
+		sm.resetTransport()
+		return true
+	}
+	return false
+}
+
+func (sm *StaticTokenAuthManager) clearConnErrors() {
+	sm.mu.Lock()
+	sm.consecutiveConnErrors = 0
+	sm.mu.Unlock()
+}
+
+func (sm *StaticTokenAuthManager) resetTransport() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	logging.Info("Static token: resetting HTTP transport (after %d consecutive errors)",
+		sm.consecutiveConnErrors)
+
+	if sm.transport != nil {
+		sm.transport.CloseIdleConnections()
+	}
+
+	sm.transport = createTransport(sm.config)
+	sm.client = &http.Client{
+		Transport: sm.transport,
+		Timeout:   5 * time.Minute,
+	}
+	sm.consecutiveConnErrors = 0
+}
+
+func (sm *StaticTokenAuthManager) getClient() *http.Client {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	return sm.client
+}

--- a/internal/auth/static_token_test.go
+++ b/internal/auth/static_token_test.go
@@ -338,3 +338,228 @@ func TestStaticTokenAuthManager_ConnectionErrorTracking(t *testing.T) {
 	}
 	sm.mu.RUnlock()
 }
+
+// ── Register tests ─────────────────────────────────────────────────────────
+
+func TestStaticTokenAuthManager_Register_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		if r.Header.Get("Authorization") != "Bearer nsk_reg_token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Decode and verify payload
+		var req staticRegisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Must use register-with-token action, NOT device-auth-start
+		if req.Action != "register-with-token" {
+			t.Errorf("Expected action 'register-with-token', got %q", req.Action)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.Version != "1.0.0" {
+			t.Errorf("Expected version '1.0.0', got %q", req.Version)
+		}
+		if req.Hostname == "" {
+			t.Error("Expected non-empty hostname")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "new_agent_xyz"})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_reg_token",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+	sm := NewStaticTokenAuthManager(cfg)
+
+	resp, err := sm.Register("1.0.0")
+	if err != nil {
+		t.Fatalf("Register() unexpected error: %v", err)
+	}
+	if resp.AgentID != "new_agent_xyz" {
+		t.Errorf("AgentID = %q, want 'new_agent_xyz'", resp.AgentID)
+	}
+}
+
+func TestStaticTokenAuthManager_Register_NoDeviceAuth(t *testing.T) {
+	// Ensure Register does NOT call device-auth-start or authorize.
+	// Any request with those actions should fail this test.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+
+		action, _ := body["action"].(string)
+		if action == "device-auth-start" {
+			t.Error("Register MUST NOT call device-auth-start")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if action == "authorize" {
+			t.Error("Register MUST NOT call authorize")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if action != "register-with-token" {
+			t.Errorf("Expected action 'register-with-token', got %q", action)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "agent_no_device_auth"})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_test_no_device",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+	sm := NewStaticTokenAuthManager(cfg)
+
+	resp, err := sm.Register("0.0.15")
+	if err != nil {
+		t.Fatalf("Register() unexpected error: %v", err)
+	}
+	if resp.AgentID != "agent_no_device_auth" {
+		t.Errorf("AgentID = %q, want 'agent_no_device_auth'", resp.AgentID)
+	}
+}
+
+func TestStaticTokenAuthManager_Register_IncludesSystemInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req staticRegisterRequest
+		json.NewDecoder(r.Body).Decode(&req)
+
+		if req.Hostname == "" {
+			t.Error("Missing hostname")
+		}
+		if req.OSType == "" {
+			t.Error("Missing os_type")
+		}
+		if req.PlatformFamily == "" {
+			t.Error("Missing platform_family")
+		}
+		if req.Version == "" {
+			t.Error("Missing version")
+		}
+		// primary_ip and kernel_version may be "unknown" in CI but should be present
+		if req.PrimaryIP == "" {
+			t.Error("Missing primary_ip")
+		}
+		if req.KernelVersion == "" {
+			t.Error("Missing kernel_version")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "agent_sysinfo"})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_sysinfo_test",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+	sm := NewStaticTokenAuthManager(cfg)
+
+	_, err := sm.Register("0.0.15")
+	if err != nil {
+		t.Fatalf("Register() unexpected error: %v", err)
+	}
+}
+
+func TestStaticTokenAuthManager_Register_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(StaticRegisterResponse{
+			Error:            "invalid_token",
+			ErrorDescription: "token revoked",
+		})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_bad_token",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+	sm := NewStaticTokenAuthManager(cfg)
+
+	_, err := sm.Register("1.0.0")
+	if err == nil {
+		t.Fatal("Expected error for error response")
+	}
+	if !contains(err.Error(), "invalid_token") {
+		t.Errorf("Error = %q, expected to contain 'invalid_token'", err.Error())
+	}
+}
+
+func TestStaticTokenAuthManager_Register_MissingAgentID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(StaticRegisterResponse{})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_no_id",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+	sm := NewStaticTokenAuthManager(cfg)
+
+	_, err := sm.Register("1.0.0")
+	if err == nil {
+		t.Fatal("Expected error when agent_id is missing from response")
+	}
+	if !contains(err.Error(), "missing agent_id") {
+		t.Errorf("Error = %q, expected to contain 'missing agent_id'", err.Error())
+	}
+}
+
+func TestStaticTokenAuthManager_Register_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"unauthorized","error_description":"bad token"}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_wrong",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+	sm := NewStaticTokenAuthManager(cfg)
+
+	_, err := sm.Register("1.0.0")
+	if err == nil {
+		t.Fatal("Expected error for 401 response")
+	}
+}
+
+// contains is a test helper
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/static_token_test.go
+++ b/internal/auth/static_token_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"nannyagent/internal/config"
@@ -166,7 +167,7 @@ func TestStaticTokenAuthManager_AuthenticatedRequest(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		resp := map[string]interface{}{"success": true, "message": "ok"}
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -212,7 +213,7 @@ func TestStaticTokenAuthManager_AuthenticatedRequest_NoAgentID(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
 	}))
 	defer server.Close()
 
@@ -240,7 +241,7 @@ func TestStaticTokenAuthManager_AuthenticatedDo(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer server.Close()
 
@@ -257,7 +258,7 @@ func TestStaticTokenAuthManager_AuthenticatedDo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status 200, got %d", resp.StatusCode)
@@ -372,7 +373,7 @@ func TestStaticTokenAuthManager_Register_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "new_agent_xyz"})
+		_ = json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "new_agent_xyz"})
 	}))
 	defer server.Close()
 
@@ -397,7 +398,7 @@ func TestStaticTokenAuthManager_Register_NoDeviceAuth(t *testing.T) {
 	// Any request with those actions should fail this test.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]interface{}
-		json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewDecoder(r.Body).Decode(&body)
 
 		action, _ := body["action"].(string)
 		if action == "device-auth-start" {
@@ -417,7 +418,7 @@ func TestStaticTokenAuthManager_Register_NoDeviceAuth(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "agent_no_device_auth"})
+		_ = json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "agent_no_device_auth"})
 	}))
 	defer server.Close()
 
@@ -440,7 +441,7 @@ func TestStaticTokenAuthManager_Register_NoDeviceAuth(t *testing.T) {
 func TestStaticTokenAuthManager_Register_IncludesSystemInfo(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req staticRegisterRequest
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 
 		if req.Hostname == "" {
 			t.Error("Missing hostname")
@@ -463,7 +464,7 @@ func TestStaticTokenAuthManager_Register_IncludesSystemInfo(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "agent_sysinfo"})
+		_ = json.NewEncoder(w).Encode(StaticRegisterResponse{AgentID: "agent_sysinfo"})
 	}))
 	defer server.Close()
 
@@ -484,7 +485,7 @@ func TestStaticTokenAuthManager_Register_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(StaticRegisterResponse{
+		_ = json.NewEncoder(w).Encode(StaticRegisterResponse{
 			Error:            "invalid_token",
 			ErrorDescription: "token revoked",
 		})
@@ -502,7 +503,7 @@ func TestStaticTokenAuthManager_Register_ServerError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error for error response")
 	}
-	if !contains(err.Error(), "invalid_token") {
+	if !strings.Contains(err.Error(), "invalid_token") {
 		t.Errorf("Error = %q, expected to contain 'invalid_token'", err.Error())
 	}
 }
@@ -511,7 +512,7 @@ func TestStaticTokenAuthManager_Register_MissingAgentID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(StaticRegisterResponse{})
+		_ = json.NewEncoder(w).Encode(StaticRegisterResponse{})
 	}))
 	defer server.Close()
 
@@ -526,7 +527,7 @@ func TestStaticTokenAuthManager_Register_MissingAgentID(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error when agent_id is missing from response")
 	}
-	if !contains(err.Error(), "missing agent_id") {
+	if !strings.Contains(err.Error(), "missing agent_id") {
 		t.Errorf("Error = %q, expected to contain 'missing agent_id'", err.Error())
 	}
 }
@@ -534,7 +535,7 @@ func TestStaticTokenAuthManager_Register_MissingAgentID(t *testing.T) {
 func TestStaticTokenAuthManager_Register_Unauthorized(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"error":"unauthorized","error_description":"bad token"}`))
+		_, _ = w.Write([]byte(`{"error":"unauthorized","error_description":"bad token"}`))
 	}))
 	defer server.Close()
 
@@ -549,17 +550,4 @@ func TestStaticTokenAuthManager_Register_Unauthorized(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error for 401 response")
 	}
-}
-
-// contains is a test helper
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
-}
-func containsStr(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/auth/static_token_test.go
+++ b/internal/auth/static_token_test.go
@@ -1,0 +1,340 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"nannyagent/internal/config"
+)
+
+func TestNewStaticTokenAuthManager(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		StaticToken:   "nsk_abc123def456",
+		AgentID:       "agent_test_1",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+	if sm == nil {
+		t.Fatal("Expected StaticTokenAuthManager to be created")
+	}
+	if sm.token != "nsk_abc123def456" {
+		t.Errorf("Expected token nsk_abc123def456, got %s", sm.token)
+	}
+	if sm.agentID != "agent_test_1" {
+		t.Errorf("Expected agentID agent_test_1, got %s", sm.agentID)
+	}
+	if sm.client == nil {
+		t.Error("HTTP client not initialized")
+	}
+}
+
+func TestStaticTokenAuthManager_GetCurrentAgentID(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		StaticToken:   "nsk_abc123",
+		AgentID:       "agent_42",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	id, err := sm.GetCurrentAgentID()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if id != "agent_42" {
+		t.Errorf("Expected agent_42, got %s", id)
+	}
+}
+
+func TestStaticTokenAuthManager_GetCurrentAgentID_Missing(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		StaticToken:   "nsk_abc123",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	_, err := sm.GetCurrentAgentID()
+	if err == nil {
+		t.Error("Expected error for missing agent ID")
+	}
+}
+
+func TestStaticTokenAuthManager_GetCurrentAccessToken(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		StaticToken:   "nsk_token_value",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	token, err := sm.GetCurrentAccessToken()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if token != "nsk_token_value" {
+		t.Errorf("Expected nsk_token_value, got %s", token)
+	}
+}
+
+func TestStaticTokenAuthManager_GetCurrentAccessToken_Missing(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	_, err := sm.GetCurrentAccessToken()
+	if err == nil {
+		t.Error("Expected error for missing static token")
+	}
+}
+
+func TestStaticTokenAuthManager_EnsureAuthenticated(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		StaticToken:   "nsk_valid",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	err := sm.EnsureAuthenticated()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestStaticTokenAuthManager_EnsureAuthenticated_NoToken(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	err := sm.EnsureAuthenticated()
+	if err == nil {
+		t.Error("Expected error for missing static token")
+	}
+}
+
+func TestStaticTokenAuthManager_SetAgentID(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:    "http://localhost:8090",
+		StaticToken:   "nsk_abc",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	sm.SetAgentID("new_agent_id")
+	id, err := sm.GetCurrentAgentID()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if id != "new_agent_id" {
+		t.Errorf("Expected new_agent_id, got %s", id)
+	}
+}
+
+func TestStaticTokenAuthManager_AuthenticatedRequest(t *testing.T) {
+	// Create a test HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify authorization header
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer nsk_test_token_123" {
+			t.Errorf("Expected Bearer nsk_test_token_123, got %s", authHeader)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Verify X-Agent-ID header
+		agentID := r.Header.Get("X-Agent-ID")
+		if agentID != "agent_abc" {
+			t.Errorf("Expected X-Agent-ID agent_abc, got %s", agentID)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		resp := map[string]interface{}{"success": true, "message": "ok"}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_test_token_123",
+		AgentID:       "agent_abc",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	statusCode, body, err := sm.AuthenticatedRequest("POST", server.URL+"/api/agent", []byte(`{"action":"ingest-metrics"}`), nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", statusCode)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+	if resp["success"] != true {
+		t.Errorf("Expected success=true, got %v", resp["success"])
+	}
+}
+
+func TestStaticTokenAuthManager_AuthenticatedRequest_NoAgentID(t *testing.T) {
+	// Verify that requests work without X-Agent-ID when agent_id is not set
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != "Bearer nsk_test_token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// X-Agent-ID should NOT be present
+		agentID := r.Header.Get("X-Agent-ID")
+		if agentID != "" {
+			t.Errorf("Expected no X-Agent-ID header, got %s", agentID)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_test_token",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	statusCode, _, err := sm.AuthenticatedRequest("POST", server.URL+"/api/agent", []byte(`{}`), nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if statusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", statusCode)
+	}
+}
+
+func TestStaticTokenAuthManager_AuthenticatedDo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer nsk_do_test" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		APIBaseURL:    server.URL,
+		StaticToken:   "nsk_do_test",
+		AgentID:       "agent_do",
+		HTTPTransport: config.DefaultHTTPTransportConfig,
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	resp, err := sm.AuthenticatedDo("GET", server.URL+"/api/test", nil, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestStaticTokenAuthManager_CalculateBackoff(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:  "http://localhost:8090",
+		StaticToken: "nsk_test",
+		HTTPTransport: config.HTTPTransportConfig{
+			InitialRetryDelaySec:    30,
+			MaxRetryDelaySec:        1800,
+			TransportResetThreshold: 3,
+		},
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	// Initial backoff should be the initial delay
+	backoff := sm.calculateBackoff()
+	if backoff.Seconds() != 30 {
+		t.Errorf("Expected 30s initial backoff, got %v", backoff)
+	}
+
+	// After incrementing, backoff should increase
+	sm.incrementRetryAttempts()
+	backoff = sm.calculateBackoff()
+	if backoff.Seconds() != 60 { // 30 * 2^1
+		t.Errorf("Expected 60s backoff after 1 attempt, got %v", backoff)
+	}
+
+	// Reset should go back to initial
+	sm.resetRetryAttempts()
+	backoff = sm.calculateBackoff()
+	if backoff.Seconds() != 30 {
+		t.Errorf("Expected 30s after reset, got %v", backoff)
+	}
+}
+
+func TestStaticTokenAuthManager_ConnectionErrorTracking(t *testing.T) {
+	cfg := &config.Config{
+		APIBaseURL:  "http://localhost:8090",
+		StaticToken: "nsk_test",
+		HTTPTransport: config.HTTPTransportConfig{
+			InitialRetryDelaySec:     30,
+			MaxRetryDelaySec:         1800,
+			TransportResetThreshold:  3,
+			MaxIdleConns:             10,
+			MaxIdleConnsPerHost:      5,
+			IdleConnTimeoutSec:       30,
+			ResponseHeaderTimeoutSec: 30,
+		},
+	}
+
+	sm := NewStaticTokenAuthManager(cfg)
+
+	// Record 2 errors - should not reset
+	reset1 := sm.recordConnError()
+	if reset1 {
+		t.Error("Should not reset after 1 error")
+	}
+	reset2 := sm.recordConnError()
+	if reset2 {
+		t.Error("Should not reset after 2 errors")
+	}
+
+	// Third error should trigger reset
+	reset3 := sm.recordConnError()
+	if !reset3 {
+		t.Error("Should reset after 3 errors (threshold)")
+	}
+
+	// After reset, counter should be back to 0
+	sm.mu.RLock()
+	if sm.consecutiveConnErrors != 0 {
+		t.Errorf("Expected 0 consecutive errors after reset, got %d", sm.consecutiveConnErrors)
+	}
+	sm.mu.RUnlock()
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"nannyagent/internal/logging"
 
@@ -21,6 +23,14 @@ type Config struct {
 	MetricsInterval int    `yaml:"metrics_interval"`
 	ProxmoxInterval int    `yaml:"proxmox_interval"`
 
+	// Static Token Authentication (alternative to OAuth2)
+	// When set, bypasses the OAuth2 device flow entirely.
+	// The token must be a valid NannyAPI static token (prefixed with nsk_).
+	StaticToken string `yaml:"static_token"`
+
+	// Agent ID (required when using static token, auto-populated after registration)
+	AgentID string `yaml:"agent_id"`
+
 	// HTTP Transport Configuration - for tuning connection behavior
 	// These help address HTTP/2 connection issues with long-running agents.
 	// See docs/CONFIGURATION.md for details on when to adjust these.
@@ -34,6 +44,92 @@ type Config struct {
 
 	// Debug/Development
 	Debug bool `yaml:"debug"`
+}
+
+// CLIFlags holds all command-line flag values for merging into Config.
+type CLIFlags struct {
+	// Commands
+	Register bool
+	Status   bool
+	Diagnose string
+	Daemon   bool
+	Version  bool
+	Help     bool
+
+	// Config overrides (nil/empty means not set)
+	APIBaseURL      string
+	PortalURL       string
+	TokenPath       string
+	MetricsInterval int
+	ProxmoxInterval int
+	AgentID         string
+	Debug           bool
+	DebugSet        bool // tracks whether --debug was explicitly passed
+}
+
+// ParseCLIFlags parses command-line arguments and returns structured flags.
+// CLI arguments have the highest priority and override YAML and env config.
+func ParseCLIFlags() *CLIFlags {
+	f := &CLIFlags{}
+
+	flag.BoolVar(&f.Register, "register", false, "Register agent with NannyAI")
+	flag.BoolVar(&f.Status, "status", false, "Show agent status")
+	flag.StringVar(&f.Diagnose, "diagnose", "", "Run one-off diagnosis (e.g., --diagnose \"postgresql is slow\")")
+	flag.BoolVar(&f.Daemon, "daemon", false, "Run as daemon (systemd)")
+	flag.BoolVar(&f.Version, "version", false, "Show version")
+	flag.BoolVar(&f.Help, "help", false, "Show help")
+
+	flag.StringVar(&f.APIBaseURL, "api-url", "", "NannyAPI endpoint URL (overrides config)")
+	flag.StringVar(&f.PortalURL, "portal-url", "", "Portal URL for device authorization")
+	flag.StringVar(&f.TokenPath, "token-path", "", "Token storage path")
+	flag.IntVar(&f.MetricsInterval, "metrics-interval", 0, "Metrics collection interval in seconds")
+	flag.IntVar(&f.ProxmoxInterval, "proxmox-interval", 0, "Proxmox data collection interval in seconds")
+	flag.StringVar(&f.AgentID, "agent-id", "", "Agent ID (for static token registration)")
+	flag.BoolVar(&f.Debug, "debug", false, "Enable debug mode")
+
+	flag.Parse()
+
+	// Track whether --debug was explicitly set
+	flag.Visit(func(fl *flag.Flag) {
+		if fl.Name == "debug" {
+			f.DebugSet = true
+		}
+	})
+
+	return f
+}
+
+// ApplyCLIFlags merges CLI flag values into the config. CLI flags have the
+// highest priority and override both YAML and environment variable settings.
+// Note: static_token is intentionally NOT exposed as a CLI flag for security
+// (it would be visible in the process list). Use config.yaml or env var only.
+func (c *Config) ApplyCLIFlags(f *CLIFlags) {
+	if f.APIBaseURL != "" {
+		c.APIBaseURL = f.APIBaseURL
+	}
+	if f.PortalURL != "" {
+		c.PortalURL = f.PortalURL
+	}
+	if f.TokenPath != "" {
+		c.TokenPath = f.TokenPath
+	}
+	if f.MetricsInterval > 0 {
+		c.MetricsInterval = f.MetricsInterval
+	}
+	if f.ProxmoxInterval > 0 {
+		c.ProxmoxInterval = f.ProxmoxInterval
+	}
+	if f.AgentID != "" {
+		c.AgentID = f.AgentID
+	}
+	if f.DebugSet {
+		c.Debug = f.Debug
+	}
+}
+
+// UseStaticToken returns true if a static token is configured.
+func (c *Config) UseStaticToken() bool {
+	return c.StaticToken != "" && strings.HasPrefix(c.StaticToken, "nsk_")
 }
 
 // HTTPTransportConfig contains settings for the HTTP client transport.
@@ -130,7 +226,7 @@ func LoadConfig() (*Config, error) {
 		logging.Warning("No configuration file found at /etc/nannyagent/config.yaml. Using environment variables only.")
 	}
 
-	// Load from environment variables (highest priority - overrides file config)
+	// Load from environment variables (overrides file config, but CLI overrides env)
 	// NannyAPI configuration (primary)
 	if url := os.Getenv("NANNYAPI_URL"); url != "" {
 		config.APIBaseURL = url
@@ -146,6 +242,16 @@ func LoadConfig() (*Config, error) {
 
 	if debug := os.Getenv("DEBUG"); debug == "true" || debug == "1" {
 		config.Debug = true
+	}
+
+	// Static token from environment variable (e.g. from .env or shell)
+	if staticToken := os.Getenv("NANNYAI_STATIC_TOKEN"); staticToken != "" {
+		config.StaticToken = staticToken
+	}
+
+	// Agent ID from environment variable
+	if agentID := os.Getenv("NANNYAI_AGENT_ID"); agentID != "" {
+		config.AgentID = agentID
 	}
 
 	// Apply defaults for any zero-value HTTP transport settings
@@ -239,6 +345,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("missing required configuration: NANNYAPI_URL (for NannyAPI) must be set")
 	}
 
+	// Validate static token format if set
+	if c.StaticToken != "" && !strings.HasPrefix(c.StaticToken, "nsk_") {
+		return fmt.Errorf("static_token must start with 'nsk_' prefix")
+	}
+
 	if err := c.HTTPTransport.Validate(); err != nil {
 		return err
 	}
@@ -293,5 +404,55 @@ func (c *Config) PrintConfig() {
 	logging.Debug("Configuration:")
 	logging.Debug("  API Base URL: %s", c.APIBaseURL)
 	logging.Debug("  Metrics Interval: %d seconds", c.MetricsInterval)
+	if c.UseStaticToken() {
+		logging.Debug("  Auth Mode: static token (nsk_***)")
+		if c.AgentID != "" {
+			logging.Debug("  Agent ID: %s", c.AgentID)
+		}
+	} else {
+		logging.Debug("  Auth Mode: OAuth2 device flow")
+	}
 	logging.Debug("  Debug: %v", c.Debug)
+}
+
+// SaveAgentID writes the agent_id field back to /etc/nannyagent/config.yaml.
+// This is used after static-token registration to persist the assigned agent ID.
+func (c *Config) SaveAgentID(agentID string) error {
+	c.AgentID = agentID
+
+	configPath := "/etc/nannyagent/config.yaml"
+
+	// Read existing file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	content := string(data)
+
+	// Check if agent_id line already exists
+	if strings.Contains(content, "agent_id:") {
+		// Replace existing agent_id line
+		lines := strings.Split(content, "\n")
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "agent_id:") || strings.HasPrefix(trimmed, "# agent_id:") {
+				lines[i] = fmt.Sprintf("agent_id: \"%s\"", agentID)
+				break
+			}
+		}
+		content = strings.Join(lines, "\n")
+	} else {
+		// Append agent_id
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += fmt.Sprintf("\nagent_id: \"%s\"\n", agentID)
+	}
+
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,9 +154,9 @@ func (c *Config) ApplyCLIFlags(f *CLIFlags) {
 	}
 }
 
-// UseStaticToken returns true if a static token is configured.
+// UseStaticToken returns true if a valid-looking static token is configured.
 func (c *Config) UseStaticToken() bool {
-	return c.StaticToken != "" && strings.HasPrefix(c.StaticToken, "nsk_")
+	return len(c.StaticToken) >= MinStaticTokenLen && strings.HasPrefix(c.StaticToken, "nsk_")
 }
 
 // HTTPTransportConfig contains settings for the HTTP client transport.
@@ -571,9 +571,13 @@ func (c *Config) PrintConfig() {
 // SaveAgentID writes the agent_id field back to /etc/nannyagent/config.yaml.
 // This is used after static-token registration to persist the assigned agent ID.
 func (c *Config) SaveAgentID(agentID string) error {
-	c.AgentID = agentID
+	return c.saveAgentIDToPath(agentID, "/etc/nannyagent/config.yaml")
+}
 
-	configPath := "/etc/nannyagent/config.yaml"
+// saveAgentIDToPath writes the agent_id field to the given config file path.
+// Extracted so unit tests can target a temp file.
+func (c *Config) saveAgentIDToPath(agentID, configPath string) error {
+	c.AgentID = agentID
 
 	// Read existing file
 	data, err := os.ReadFile(configPath)
@@ -583,17 +587,20 @@ func (c *Config) SaveAgentID(agentID string) error {
 
 	content := string(data)
 
-	// Check if agent_id line already exists
-	if strings.Contains(content, "agent_id:") {
-		// Replace existing agent_id line
-		lines := strings.Split(content, "\n")
-		for i, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if strings.HasPrefix(trimmed, "agent_id:") || strings.HasPrefix(trimmed, "# agent_id:") {
-				lines[i] = fmt.Sprintf("agent_id: \"%s\"", agentID)
-				break
-			}
+	// Scan lines for an existing agent_id key and replace it.
+	// Track whether replacement occurred to decide whether to append.
+	lines := strings.Split(content, "\n")
+	replaced := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "agent_id:") || strings.HasPrefix(trimmed, "# agent_id:") {
+			lines[i] = fmt.Sprintf("agent_id: \"%s\"", agentID)
+			replaced = true
+			break
 		}
+	}
+
+	if replaced {
 		content = strings.Join(lines, "\n")
 	} else {
 		// Append agent_id

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,12 +3,39 @@ package config
 import (
 	"flag"
 	"fmt"
+	"math"
+	"net/url"
 	"os"
 	"strings"
 
 	"nannyagent/internal/logging"
 
 	"gopkg.in/yaml.v3"
+)
+
+// Validation limits — protect against typos, overflow, and unreasonable values.
+const (
+	// Interval bounds (seconds)
+	MinInterval = 5         // 5 seconds
+	MaxInterval = 7 * 86400 // 7 days in seconds (604 800)
+
+	// Token renewal bounds
+	MaxRenewalThresholdDays = 365        // 1 year
+	MaxRenewalIntervalSecs  = 30 * 86400 // 30 days in seconds
+
+	// HTTP transport bounds
+	MaxIdleConns            = 1000
+	MaxIdleConnTimeoutSec   = 3600  // 1 hour
+	MaxResponseHeaderSec    = 300   // 5 minutes
+	MaxRetryDelay           = 86400 // 1 day
+	MaxTransportResetThresh = 100
+
+	// String length limits
+	MaxURLLength       = 2048
+	MaxTokenPathLength = 4096
+	MaxStaticTokenLen  = 512
+	MinStaticTokenLen  = 5 // "nsk_" + at least 1 char
+	MaxAgentIDLength   = 256
 )
 
 type Config struct {
@@ -316,11 +343,20 @@ func (c *Config) validateTokenRenewal() error {
 	if c.TokenRenewalThresholdDays <= 0 {
 		return fmt.Errorf("token_renewal_threshold_days must be > 0 (got %d)", c.TokenRenewalThresholdDays)
 	}
+	if c.TokenRenewalThresholdDays > MaxRenewalThresholdDays {
+		return fmt.Errorf("token_renewal_threshold_days must be <= %d (got %d)", MaxRenewalThresholdDays, c.TokenRenewalThresholdDays)
+	}
 	if c.TokenRenewalCheckIntervalSecs <= 0 {
 		return fmt.Errorf("token_renewal_check_interval_secs must be > 0 (got %d)", c.TokenRenewalCheckIntervalSecs)
 	}
+	if c.TokenRenewalCheckIntervalSecs > MaxRenewalIntervalSecs {
+		return fmt.Errorf("token_renewal_check_interval_secs must be <= %d (got %d)", MaxRenewalIntervalSecs, c.TokenRenewalCheckIntervalSecs)
+	}
 	if c.TokenRenewalRetryIntervalSecs <= 0 {
 		return fmt.Errorf("token_renewal_retry_interval_secs must be > 0 (got %d)", c.TokenRenewalRetryIntervalSecs)
+	}
+	if c.TokenRenewalRetryIntervalSecs > MaxRenewalIntervalSecs {
+		return fmt.Errorf("token_renewal_retry_interval_secs must be <= %d (got %d)", MaxRenewalIntervalSecs, c.TokenRenewalRetryIntervalSecs)
 	}
 	return nil
 }
@@ -339,17 +375,67 @@ func loadYAMLConfig(config *Config, path string) error {
 	return nil
 }
 
-// Validate checks if all required configuration is present
+// Validate checks if all required configuration is present and all values are
+// within acceptable bounds.  This is called after YAML + env loading, and again
+// after CLI flags are merged (via ValidateAfterMerge).
 func (c *Config) Validate() error {
+	// ── Required fields ──────────────────────────────────────────────────
 	if c.APIBaseURL == "" {
 		return fmt.Errorf("missing required configuration: NANNYAPI_URL (for NannyAPI) must be set")
 	}
 
-	// Validate static token format if set
-	if c.StaticToken != "" && !strings.HasPrefix(c.StaticToken, "nsk_") {
-		return fmt.Errorf("static_token must start with 'nsk_' prefix")
+	// ── URL validation ───────────────────────────────────────────────────
+	if err := validateURL(c.APIBaseURL, "nannyapi_url"); err != nil {
+		return err
+	}
+	if c.PortalURL != "" {
+		if err := validateURL(c.PortalURL, "portal_url"); err != nil {
+			return err
+		}
 	}
 
+	// ── Token path ──────────────────────────────────────────────────────
+	if c.TokenPath != "" {
+		if len(c.TokenPath) > MaxTokenPathLength {
+			return fmt.Errorf("token_path is too long (%d chars, max %d)", len(c.TokenPath), MaxTokenPathLength)
+		}
+		if !strings.HasPrefix(c.TokenPath, "/") {
+			return fmt.Errorf("token_path must be an absolute path (got %q)", c.TokenPath)
+		}
+	}
+
+	// ── Static token ────────────────────────────────────────────────────
+	if c.StaticToken != "" {
+		if !strings.HasPrefix(c.StaticToken, "nsk_") {
+			return fmt.Errorf("static_token must start with 'nsk_' prefix")
+		}
+		if len(c.StaticToken) < MinStaticTokenLen {
+			return fmt.Errorf("static_token is too short (must be at least %d characters)", MinStaticTokenLen)
+		}
+		if len(c.StaticToken) > MaxStaticTokenLen {
+			return fmt.Errorf("static_token is too long (%d chars, max %d)", len(c.StaticToken), MaxStaticTokenLen)
+		}
+	}
+
+	// ── Agent ID ────────────────────────────────────────────────────────
+	if c.AgentID != "" {
+		if len(c.AgentID) > MaxAgentIDLength {
+			return fmt.Errorf("agent_id is too long (%d chars, max %d)", len(c.AgentID), MaxAgentIDLength)
+		}
+		if strings.TrimSpace(c.AgentID) == "" {
+			return fmt.Errorf("agent_id must not be blank/whitespace-only")
+		}
+	}
+
+	// ── Intervals ───────────────────────────────────────────────────────
+	if err := validateInterval(c.MetricsInterval, "metrics_interval"); err != nil {
+		return err
+	}
+	if err := validateInterval(c.ProxmoxInterval, "proxmox_interval"); err != nil {
+		return err
+	}
+
+	// ── Subsystem validations ───────────────────────────────────────────
 	if err := c.HTTPTransport.Validate(); err != nil {
 		return err
 	}
@@ -361,13 +447,57 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// ValidateAfterMerge should be called after ApplyCLIFlags to re-validate the
+// final merged configuration.  It is a convenience wrapper around Validate().
+func (c *Config) ValidateAfterMerge() error {
+	return c.Validate()
+}
+
+// validateURL checks that a URL string is well-formed and uses http or https.
+func validateURL(raw, field string) error {
+	if len(raw) > MaxURLLength {
+		return fmt.Errorf("%s is too long (%d chars, max %d)", field, len(raw), MaxURLLength)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s is not a valid URL: %w", field, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s must use http or https scheme (got %q)", field, u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s is missing a host", field)
+	}
+	return nil
+}
+
+// validateInterval checks that a collection interval is within [MinInterval, MaxInterval].
+func validateInterval(value int, field string) error {
+	if value <= 0 {
+		return fmt.Errorf("%s must be > 0 (got %d)", field, value)
+	}
+	if value < MinInterval {
+		return fmt.Errorf("%s must be >= %d seconds (got %d)", field, MinInterval, value)
+	}
+	if value > MaxInterval {
+		return fmt.Errorf("%s must be <= %d seconds (got %d)", field, MaxInterval, value)
+	}
+	return nil
+}
+
 // Validate checks that HTTPTransportConfig values are sensible and not internally inconsistent.
 func (h *HTTPTransportConfig) Validate() error {
 	if h.InitialRetryDelaySec <= 0 {
 		return fmt.Errorf("http_transport.initial_retry_delay_sec must be > 0 (got %d)", h.InitialRetryDelaySec)
 	}
+	if h.InitialRetryDelaySec > MaxRetryDelay {
+		return fmt.Errorf("http_transport.initial_retry_delay_sec must be <= %d (got %d)", MaxRetryDelay, h.InitialRetryDelaySec)
+	}
 	if h.MaxRetryDelaySec <= 0 {
 		return fmt.Errorf("http_transport.max_retry_delay_sec must be > 0 (got %d)", h.MaxRetryDelaySec)
+	}
+	if h.MaxRetryDelaySec > MaxRetryDelay {
+		return fmt.Errorf("http_transport.max_retry_delay_sec must be <= %d (got %d)", MaxRetryDelay, h.MaxRetryDelaySec)
 	}
 	if h.MaxRetryDelaySec < h.InitialRetryDelaySec {
 		return fmt.Errorf("http_transport.max_retry_delay_sec (%d) must be >= initial_retry_delay_sec (%d)", h.MaxRetryDelaySec, h.InitialRetryDelaySec)
@@ -375,17 +505,40 @@ func (h *HTTPTransportConfig) Validate() error {
 	if h.TransportResetThreshold < 1 {
 		return fmt.Errorf("http_transport.transport_reset_threshold must be >= 1 (got %d)", h.TransportResetThreshold)
 	}
+	if h.TransportResetThreshold > MaxTransportResetThresh {
+		return fmt.Errorf("http_transport.transport_reset_threshold must be <= %d (got %d)", MaxTransportResetThresh, h.TransportResetThreshold)
+	}
 	if h.IdleConnTimeoutSec < 0 {
 		return fmt.Errorf("http_transport.idle_conn_timeout_sec must be >= 0 (got %d)", h.IdleConnTimeoutSec)
+	}
+	if h.IdleConnTimeoutSec > MaxIdleConnTimeoutSec {
+		return fmt.Errorf("http_transport.idle_conn_timeout_sec must be <= %d (got %d)", MaxIdleConnTimeoutSec, h.IdleConnTimeoutSec)
 	}
 	if h.ResponseHeaderTimeoutSec < 0 {
 		return fmt.Errorf("http_transport.response_header_timeout_sec must be >= 0 (got %d)", h.ResponseHeaderTimeoutSec)
 	}
+	if h.ResponseHeaderTimeoutSec > MaxResponseHeaderSec {
+		return fmt.Errorf("http_transport.response_header_timeout_sec must be <= %d (got %d)", MaxResponseHeaderSec, h.ResponseHeaderTimeoutSec)
+	}
 	if h.MaxIdleConns < 0 {
 		return fmt.Errorf("http_transport.max_idle_conns must be >= 0 (got %d)", h.MaxIdleConns)
 	}
+	if h.MaxIdleConns > MaxIdleConns {
+		return fmt.Errorf("http_transport.max_idle_conns must be <= %d (got %d)", MaxIdleConns, h.MaxIdleConns)
+	}
 	if h.MaxIdleConnsPerHost < 0 {
 		return fmt.Errorf("http_transport.max_idle_conns_per_host must be >= 0 (got %d)", h.MaxIdleConnsPerHost)
+	}
+	if h.MaxIdleConnsPerHost > MaxIdleConns {
+		return fmt.Errorf("http_transport.max_idle_conns_per_host must be <= %d (got %d)", MaxIdleConns, h.MaxIdleConnsPerHost)
+	}
+	// Consistency: per-host should not exceed total
+	if h.MaxIdleConns > 0 && h.MaxIdleConnsPerHost > h.MaxIdleConns {
+		return fmt.Errorf("http_transport.max_idle_conns_per_host (%d) must be <= max_idle_conns (%d)", h.MaxIdleConnsPerHost, h.MaxIdleConns)
+	}
+	// Guard against integer overflow when values are used in time.Duration multiplication
+	if h.MaxRetryDelaySec > math.MaxInt64/int(1e9) {
+		return fmt.Errorf("http_transport.max_retry_delay_sec would overflow time.Duration")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,7 +368,7 @@ func TestUseStaticToken(t *testing.T) {
 		{"valid nsk token", "nsk_abc123def456", true},
 		{"empty token", "", false},
 		{"non-nsk prefix", "invalid_token", false},
-		{"just nsk_", "nsk_", true},
+		{"just nsk_", "nsk_", false},
 		{"partial nsk", "nsk", false},
 	}
 
@@ -546,16 +546,10 @@ static_token: "nsk_abc123"
 		t.Fatalf("Failed to create test config: %v", err)
 	}
 
-	// Simulate SaveAgentID logic (appending)
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("Failed to read: %v", err)
-	}
-	content := string(data)
-	content += "\nagent_id: \"new_agent_123\"\n"
-
-	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
-		t.Fatalf("Failed to write: %v", err)
+	// Call the real saveAgentIDToPath method
+	cfg := &Config{}
+	if err := cfg.saveAgentIDToPath("new_agent_123", configPath); err != nil {
+		t.Fatalf("saveAgentIDToPath() error: %v", err)
 	}
 
 	var loadedCfg Config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -356,3 +356,210 @@ func TestHTTPTransportConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestUseStaticToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		staticToken string
+		want        bool
+	}{
+		{"valid nsk token", "nsk_abc123def456", true},
+		{"empty token", "", false},
+		{"non-nsk prefix", "invalid_token", false},
+		{"just nsk_", "nsk_", true},
+		{"partial nsk", "nsk", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{StaticToken: tt.staticToken}
+			if got := cfg.UseStaticToken(); got != tt.want {
+				t.Errorf("UseStaticToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate_StaticToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		staticToken string
+		wantErr     bool
+	}{
+		{"valid nsk token", "nsk_abc123", false},
+		{"empty token", "", false},
+		{"invalid prefix", "bad_token", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				APIBaseURL:                    "https://test.nannyai.dev",
+				StaticToken:                   tt.staticToken,
+				HTTPTransport:                 DefaultHTTPTransportConfig,
+				TokenRenewalThresholdDays:     DefaultConfig.TokenRenewalThresholdDays,
+				TokenRenewalCheckIntervalSecs: DefaultConfig.TokenRenewalCheckIntervalSecs,
+				TokenRenewalRetryIntervalSecs: DefaultConfig.TokenRenewalRetryIntervalSecs,
+			}
+			err := cfg.Validate()
+			if tt.wantErr && err == nil {
+				t.Error("Expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestApplyCLIFlags(t *testing.T) {
+	cfg := &Config{
+		APIBaseURL:      "https://yaml.nannyai.dev",
+		PortalURL:       "https://yaml.portal.dev",
+		TokenPath:       "/yaml/token.json",
+		MetricsInterval: 30,
+		ProxmoxInterval: 300,
+		Debug:           false,
+	}
+
+	flags := &CLIFlags{
+		APIBaseURL:      "https://cli.nannyai.dev",
+		MetricsInterval: 60,
+		AgentID:         "cli_agent_id",
+		Debug:           true,
+		DebugSet:        true,
+	}
+
+	cfg.ApplyCLIFlags(flags)
+
+	if cfg.APIBaseURL != "https://cli.nannyai.dev" {
+		t.Errorf("APIBaseURL = %v, want https://cli.nannyai.dev", cfg.APIBaseURL)
+	}
+	if cfg.MetricsInterval != 60 {
+		t.Errorf("MetricsInterval = %v, want 60", cfg.MetricsInterval)
+	}
+	if cfg.AgentID != "cli_agent_id" {
+		t.Errorf("AgentID = %v, want cli_agent_id", cfg.AgentID)
+	}
+	if !cfg.Debug {
+		t.Error("Debug should be true")
+	}
+
+	// Non-overridden values should remain
+	if cfg.PortalURL != "https://yaml.portal.dev" {
+		t.Errorf("PortalURL = %v, want https://yaml.portal.dev", cfg.PortalURL)
+	}
+	if cfg.TokenPath != "/yaml/token.json" {
+		t.Errorf("TokenPath = %v, want /yaml/token.json", cfg.TokenPath)
+	}
+	if cfg.ProxmoxInterval != 300 {
+		t.Errorf("ProxmoxInterval = %v, want 300", cfg.ProxmoxInterval)
+	}
+}
+
+func TestApplyCLIFlags_NoOverride(t *testing.T) {
+	cfg := &Config{
+		APIBaseURL:      "https://yaml.nannyai.dev",
+		MetricsInterval: 30,
+		Debug:           true,
+	}
+
+	flags := &CLIFlags{}
+	cfg.ApplyCLIFlags(flags)
+
+	if cfg.APIBaseURL != "https://yaml.nannyai.dev" {
+		t.Errorf("APIBaseURL changed unexpectedly to %v", cfg.APIBaseURL)
+	}
+	if cfg.MetricsInterval != 30 {
+		t.Errorf("MetricsInterval changed unexpectedly to %v", cfg.MetricsInterval)
+	}
+	if !cfg.Debug {
+		t.Error("Debug should remain true when DebugSet is false")
+	}
+}
+
+func TestLoadConfig_StaticToken_FromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+nannyapi_url: https://test-api.nannyai.dev
+static_token: "nsk_abc123def456"
+agent_id: "agent_test_42"
+`
+	err := os.WriteFile(configPath, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	config := DefaultConfig
+	err = loadYAMLConfig(&config, configPath)
+	if err != nil {
+		t.Fatalf("loadYAMLConfig() failed: %v", err)
+	}
+
+	if config.StaticToken != "nsk_abc123def456" {
+		t.Errorf("StaticToken = %v, want nsk_abc123def456", config.StaticToken)
+	}
+	if config.AgentID != "agent_test_42" {
+		t.Errorf("AgentID = %v, want agent_test_42", config.AgentID)
+	}
+}
+
+func TestLoadConfig_StaticToken_EnvOverride(t *testing.T) {
+	_ = os.Setenv("NANNYAI_STATIC_TOKEN", "nsk_env_token")
+	_ = os.Setenv("NANNYAI_AGENT_ID", "env_agent_id")
+	defer func() {
+		_ = os.Unsetenv("NANNYAI_STATIC_TOKEN")
+		_ = os.Unsetenv("NANNYAI_AGENT_ID")
+	}()
+
+	config := DefaultConfig
+	if staticToken := os.Getenv("NANNYAI_STATIC_TOKEN"); staticToken != "" {
+		config.StaticToken = staticToken
+	}
+	if agentID := os.Getenv("NANNYAI_AGENT_ID"); agentID != "" {
+		config.AgentID = agentID
+	}
+
+	if config.StaticToken != "nsk_env_token" {
+		t.Errorf("StaticToken = %v, want nsk_env_token", config.StaticToken)
+	}
+	if config.AgentID != "env_agent_id" {
+		t.Errorf("AgentID = %v, want env_agent_id", config.AgentID)
+	}
+}
+
+func TestSaveAgentID_Append(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	initialContent := `nannyapi_url: "https://test-api.nannyai.dev"
+static_token: "nsk_abc123"
+`
+	err := os.WriteFile(configPath, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	// Simulate SaveAgentID logic (appending)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+	content := string(data)
+	content += "\nagent_id: \"new_agent_123\"\n"
+
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatalf("Failed to write: %v", err)
+	}
+
+	var loadedCfg Config
+	err = loadYAMLConfig(&loadedCfg, configPath)
+	if err != nil {
+		t.Fatalf("Failed to reload config: %v", err)
+	}
+	if loadedCfg.AgentID != "new_agent_123" {
+		t.Errorf("AgentID = %v, want new_agent_123", loadedCfg.AgentID)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,6 +101,8 @@ func TestLoadConfig_EnvFile(t *testing.T) {
 func TestValidate_Success(t *testing.T) {
 	config := &Config{
 		APIBaseURL:                    "https://test-api.nannyai.dev",
+		MetricsInterval:               30,
+		ProxmoxInterval:               300,
 		HTTPTransport:                 DefaultHTTPTransportConfig,
 		TokenRenewalThresholdDays:     DefaultConfig.TokenRenewalThresholdDays,
 		TokenRenewalCheckIntervalSecs: DefaultConfig.TokenRenewalCheckIntervalSecs,
@@ -396,6 +398,8 @@ func TestValidate_StaticToken(t *testing.T) {
 			cfg := &Config{
 				APIBaseURL:                    "https://test.nannyai.dev",
 				StaticToken:                   tt.staticToken,
+				MetricsInterval:               30,
+				ProxmoxInterval:               300,
 				HTTPTransport:                 DefaultHTTPTransportConfig,
 				TokenRenewalThresholdDays:     DefaultConfig.TokenRenewalThresholdDays,
 				TokenRenewalCheckIntervalSecs: DefaultConfig.TokenRenewalCheckIntervalSecs,
@@ -561,5 +565,533 @@ static_token: "nsk_abc123"
 	}
 	if loadedCfg.AgentID != "new_agent_123" {
 		t.Errorf("AgentID = %v, want new_agent_123", loadedCfg.AgentID)
+	}
+}
+
+// ── Validation Tests ────────────────────────────────────────────────────────
+
+// validConfig returns a fully valid Config for use as a test baseline.
+// Tests modify one field at a time to isolate each validation.
+func validConfig() *Config {
+	return &Config{
+		APIBaseURL:                    "https://api.nannyai.dev",
+		PortalURL:                     "https://nannyai.dev",
+		TokenPath:                     "/var/lib/nannyagent/token.json",
+		MetricsInterval:               30,
+		ProxmoxInterval:               300,
+		HTTPTransport:                 DefaultHTTPTransportConfig,
+		TokenRenewalThresholdDays:     7,
+		TokenRenewalCheckIntervalSecs: 21600,
+		TokenRenewalRetryIntervalSecs: 3600,
+	}
+}
+
+func TestValidate_URL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		field   string // "api" or "portal"
+		wantErr string
+	}{
+		{"valid https", "https://api.nannyai.dev", "api", ""},
+		{"valid http", "http://localhost:8090", "api", ""},
+		{"valid with port", "https://api.nannyai.dev:443", "api", ""},
+		{"valid with path", "https://api.nannyai.dev/v1", "api", ""},
+		{"ftp scheme rejected", "ftp://api.nannyai.dev", "api", "must use http or https"},
+		{"no scheme", "api.nannyai.dev", "api", "must use http or https"},
+		{"empty scheme", "://api.nannyai.dev", "api", "not a valid URL"},
+		{"missing host", "https://", "api", "missing a host"},
+		{"too long URL", "https://" + strings.Repeat("a", MaxURLLength), "api", "too long"},
+
+		// portal_url
+		{"valid portal", "https://nannyai.dev", "portal", ""},
+		{"invalid portal scheme", "ws://nannyai.dev", "portal", "must use http or https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			if tt.field == "api" {
+				cfg.APIBaseURL = tt.url
+			} else {
+				cfg.PortalURL = tt.url
+			}
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_TokenPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenPath string
+		wantErr   string
+	}{
+		{"valid absolute path", "/var/lib/nannyagent/token.json", ""},
+		{"empty is valid", "", ""},
+		{"relative path rejected", "relative/token.json", "must be an absolute path"},
+		{"just filename rejected", "token.json", "must be an absolute path"},
+		{"too long path", "/" + strings.Repeat("a", MaxTokenPathLength), "too long"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.TokenPath = tt.tokenPath
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_StaticTokenBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantErr string
+	}{
+		{"valid token", "nsk_cf4da3f36fad8ea014f5c73b2610e51d", ""},
+		{"empty is valid", "", ""},
+		{"wrong prefix", "bad_token", "must start with 'nsk_'"},
+		{"nsk_ alone too short", "nsk_", "too short"},
+		{"min length exact", "nsk_x", ""},
+		{"too long", "nsk_" + strings.Repeat("a", MaxStaticTokenLen), "too long"},
+		{"max length exact", "nsk_" + strings.Repeat("a", MaxStaticTokenLen-4), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.StaticToken = tt.token
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_AgentID(t *testing.T) {
+	tests := []struct {
+		name    string
+		agentID string
+		wantErr string
+	}{
+		{"valid agent ID", "agent_abc123", ""},
+		{"empty is valid", "", ""},
+		{"whitespace-only rejected", "   ", "must not be blank"},
+		{"tab-only rejected", "\t", "must not be blank"},
+		{"too long", strings.Repeat("x", MaxAgentIDLength+1), "too long"},
+		{"max length exact", strings.Repeat("x", MaxAgentIDLength), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.AgentID = tt.agentID
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_MetricsInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr string
+	}{
+		{"valid 30s", 30, ""},
+		{"valid max", MaxInterval, ""},
+		{"valid min", MinInterval, ""},
+		{"zero rejected", 0, "must be > 0"},
+		{"negative rejected", -1, "must be > 0"},
+		{"too small", MinInterval - 1, "must be >="},
+		{"too large", MaxInterval + 1, "must be <="},
+		{"large negative (overflow-ish)", -2147483648, "must be > 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.MetricsInterval = tt.value
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_ProxmoxInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr string
+	}{
+		{"valid 300s", 300, ""},
+		{"zero rejected", 0, "must be > 0"},
+		{"negative rejected", -100, "must be > 0"},
+		{"too large", MaxInterval + 1, "must be <="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.ProxmoxInterval = tt.value
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_TokenRenewalBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*Config)
+		wantErr string
+	}{
+		{
+			name:    "all valid defaults",
+			modify:  func(c *Config) {},
+			wantErr: "",
+		},
+		{
+			name:    "threshold_days negative",
+			modify:  func(c *Config) { c.TokenRenewalThresholdDays = -1 },
+			wantErr: "token_renewal_threshold_days must be > 0",
+		},
+		{
+			name:    "threshold_days too large",
+			modify:  func(c *Config) { c.TokenRenewalThresholdDays = MaxRenewalThresholdDays + 1 },
+			wantErr: "token_renewal_threshold_days must be <=",
+		},
+		{
+			name:    "threshold_days at max",
+			modify:  func(c *Config) { c.TokenRenewalThresholdDays = MaxRenewalThresholdDays },
+			wantErr: "",
+		},
+		{
+			name:    "check_interval too large",
+			modify:  func(c *Config) { c.TokenRenewalCheckIntervalSecs = MaxRenewalIntervalSecs + 1 },
+			wantErr: "token_renewal_check_interval_secs must be <=",
+		},
+		{
+			name:    "retry_interval too large",
+			modify:  func(c *Config) { c.TokenRenewalRetryIntervalSecs = MaxRenewalIntervalSecs + 1 },
+			wantErr: "token_renewal_retry_interval_secs must be <=",
+		},
+		{
+			name:    "check_interval at max",
+			modify:  func(c *Config) { c.TokenRenewalCheckIntervalSecs = MaxRenewalIntervalSecs },
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			tt.modify(cfg)
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestHTTPTransportConfig_ValidateUpperBounds(t *testing.T) {
+	validBase := func() HTTPTransportConfig {
+		return DefaultHTTPTransportConfig
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(*HTTPTransportConfig)
+		wantErr string
+	}{
+		{
+			name:    "initial_retry_delay too large",
+			modify:  func(c *HTTPTransportConfig) { c.InitialRetryDelaySec = MaxRetryDelay + 1 },
+			wantErr: "initial_retry_delay_sec must be <=",
+		},
+		{
+			name:    "max_retry_delay too large",
+			modify:  func(c *HTTPTransportConfig) { c.MaxRetryDelaySec = MaxRetryDelay + 1 },
+			wantErr: "max_retry_delay_sec must be <=",
+		},
+		{
+			name:    "transport_reset_threshold too large",
+			modify:  func(c *HTTPTransportConfig) { c.TransportResetThreshold = MaxTransportResetThresh + 1 },
+			wantErr: "transport_reset_threshold must be <=",
+		},
+		{
+			name:    "idle_conn_timeout too large",
+			modify:  func(c *HTTPTransportConfig) { c.IdleConnTimeoutSec = MaxIdleConnTimeoutSec + 1 },
+			wantErr: "idle_conn_timeout_sec must be <=",
+		},
+		{
+			name:    "response_header_timeout too large",
+			modify:  func(c *HTTPTransportConfig) { c.ResponseHeaderTimeoutSec = MaxResponseHeaderSec + 1 },
+			wantErr: "response_header_timeout_sec must be <=",
+		},
+		{
+			name:    "max_idle_conns too large",
+			modify:  func(c *HTTPTransportConfig) { c.MaxIdleConns = MaxIdleConns + 1 },
+			wantErr: "max_idle_conns must be <=",
+		},
+		{
+			name:    "max_idle_conns_per_host too large",
+			modify:  func(c *HTTPTransportConfig) { c.MaxIdleConnsPerHost = MaxIdleConns + 1 },
+			wantErr: "max_idle_conns_per_host must be <=",
+		},
+		{
+			name: "per_host exceeds total",
+			modify: func(c *HTTPTransportConfig) {
+				c.MaxIdleConns = 5
+				c.MaxIdleConnsPerHost = 10
+			},
+			wantErr: "max_idle_conns_per_host (10) must be <= max_idle_conns (5)",
+		},
+		{
+			name: "at upper bounds is valid",
+			modify: func(c *HTTPTransportConfig) {
+				c.MaxIdleConns = MaxIdleConns
+				c.MaxIdleConnsPerHost = MaxIdleConns
+				c.IdleConnTimeoutSec = MaxIdleConnTimeoutSec
+				c.ResponseHeaderTimeoutSec = MaxResponseHeaderSec
+				c.TransportResetThreshold = MaxTransportResetThresh
+				c.InitialRetryDelaySec = MaxRetryDelay
+				c.MaxRetryDelaySec = MaxRetryDelay
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBase()
+			tt.modify(&cfg)
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAfterMerge_CLIOverridesInvalid(t *testing.T) {
+	cfg := validConfig()
+
+	// Apply CLI flags that introduce an invalid metrics interval
+	flags := &CLIFlags{
+		MetricsInterval: 2, // below MinInterval (5)
+	}
+	cfg.ApplyCLIFlags(flags)
+
+	err := cfg.ValidateAfterMerge()
+	if err == nil {
+		t.Error("ValidateAfterMerge() expected error for interval below minimum, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "metrics_interval") {
+		t.Errorf("ValidateAfterMerge() error = %q, expected metrics_interval mention", err.Error())
+	}
+}
+
+func TestValidateAfterMerge_CLIOverridesValid(t *testing.T) {
+	cfg := validConfig()
+
+	flags := &CLIFlags{
+		APIBaseURL:      "http://localhost:9090",
+		MetricsInterval: 60,
+	}
+	cfg.ApplyCLIFlags(flags)
+
+	err := cfg.ValidateAfterMerge()
+	if err != nil {
+		t.Errorf("ValidateAfterMerge() unexpected error: %v", err)
+	}
+	if cfg.APIBaseURL != "http://localhost:9090" {
+		t.Errorf("APIBaseURL = %v, want http://localhost:9090", cfg.APIBaseURL)
+	}
+}
+
+func TestValidate_InvalidURLViaCLI(t *testing.T) {
+	cfg := validConfig()
+
+	flags := &CLIFlags{
+		APIBaseURL: "ftp://bad-scheme.example.com",
+	}
+	cfg.ApplyCLIFlags(flags)
+
+	err := cfg.ValidateAfterMerge()
+	if err == nil {
+		t.Error("Expected error for ftp:// scheme via CLI, got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "must use http or https") {
+		t.Errorf("Error = %q, expected scheme error", err.Error())
+	}
+}
+
+func TestValidate_YAMLWithInvalidValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+nannyapi_url: https://api.nannyai.dev
+metrics_interval: -10
+proxmox_interval: 300
+`
+	err := os.WriteFile(configPath, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	cfg := DefaultConfig
+	err = loadYAMLConfig(&cfg, configPath)
+	if err != nil {
+		t.Fatalf("loadYAMLConfig() failed: %v", err)
+	}
+	cfg.HTTPTransport.ApplyDefaults()
+	cfg.ApplyTokenRenewalDefaults()
+
+	err = cfg.Validate()
+	if err == nil {
+		t.Error("Expected validation error for negative metrics_interval")
+	}
+	if err != nil && !strings.Contains(err.Error(), "metrics_interval") {
+		t.Errorf("Error = %q, expected metrics_interval mention", err.Error())
+	}
+}
+
+func TestValidate_YAMLWithOverflowInterval(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+nannyapi_url: https://api.nannyai.dev
+metrics_interval: 999999999
+proxmox_interval: 300
+`
+	err := os.WriteFile(configPath, []byte(yamlContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test config: %v", err)
+	}
+
+	cfg := DefaultConfig
+	err = loadYAMLConfig(&cfg, configPath)
+	if err != nil {
+		t.Fatalf("loadYAMLConfig() failed: %v", err)
+	}
+	cfg.HTTPTransport.ApplyDefaults()
+	cfg.ApplyTokenRenewalDefaults()
+
+	err = cfg.Validate()
+	if err == nil {
+		t.Error("Expected validation error for overflow metrics_interval")
+	}
+	if err != nil && !strings.Contains(err.Error(), "metrics_interval") {
+		t.Errorf("Error = %q, expected metrics_interval mention", err.Error())
+	}
+}
+
+func TestValidate_EnvStaticTokenInvalid(t *testing.T) {
+	cfg := validConfig()
+
+	// Simulate env var setting a bad token
+	cfg.StaticToken = "bad_prefix_token"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("Expected error for non-nsk token via env")
+	}
+	if err != nil && !strings.Contains(err.Error(), "nsk_") {
+		t.Errorf("Error = %q, expected nsk_ prefix mention", err.Error())
+	}
+}
+
+func TestValidate_RelativeTokenPathViaEnv(t *testing.T) {
+	cfg := validConfig()
+	cfg.TokenPath = "relative/path/token.json"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("Expected error for relative token_path")
+	}
+	if err != nil && !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("Error = %q, expected absolute path mention", err.Error())
 	}
 }

--- a/internal/proxmox/manager.go
+++ b/internal/proxmox/manager.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"nannyagent/internal/auth"
 	"nannyagent/internal/config"
 	"nannyagent/internal/logging"
 )
@@ -24,7 +23,7 @@ type Manager struct {
 	stopOnce  sync.Once
 }
 
-func NewManager(cfg *config.Config, auth *auth.AuthManager) *Manager {
+func NewManager(cfg *config.Config, auth Authenticator) *Manager {
 	return NewManagerWithCollector(cfg, auth, NewCollector(&RealCommandExecutor{}))
 }
 

--- a/main.go
+++ b/main.go
@@ -222,9 +222,6 @@ func runRegisterCommand(cliFlags *config.CLIFlags) {
 		os.Exit(1)
 	}
 
-	// Ensure token path uses hardcoded DataDir
-	cfg.TokenPath = filepath.Join(DataDir, "token.json")
-
 	// ── Static token registration (fully automated, no user interaction) ────
 	if cfg.UseStaticToken() {
 		runStaticTokenRegister(cfg)
@@ -345,7 +342,7 @@ func runStatusCommand(cliFlags *config.CLIFlags) {
 	// Load configuration
 	cfg, err := config.LoadConfig()
 	if err != nil {
-		fmt.Println("Configuration: Not found")
+		fmt.Printf("Configuration error: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -372,12 +369,20 @@ func runStatusCommand(cliFlags *config.CLIFlags) {
 		fmt.Println("Auth Mode: OAuth2")
 	}
 
-	// Check if token exists
-	tokenPath := filepath.Join(DataDir, "token.json")
-	if _, err := os.Stat(tokenPath); os.IsNotExist(err) {
-		fmt.Println("Not registered")
-		fmt.Println("\nRegister with: sudo nannyagent --register")
-		os.Exit(1)
+	// Check if agent is registered
+	if cfg.UseStaticToken() && cfg.AgentID != "" {
+		// In static-token mode, a configured agent_id means the agent is registered
+		// even if the token marker file is absent.
+	} else {
+		tokenPath := cfg.TokenPath
+		if tokenPath == "" {
+			tokenPath = filepath.Join(DataDir, "token.json")
+		}
+		if _, err := os.Stat(tokenPath); os.IsNotExist(err) {
+			fmt.Println("Not registered")
+			fmt.Println("\nRegister with: sudo nannyagent --register")
+			os.Exit(1)
+		}
 	}
 
 	if cfg.UseStaticToken() {
@@ -519,6 +524,9 @@ func main() {
 	cliFlags := config.ParseCLIFlags()
 
 	// Also check for commands without -- prefix (for backward compatibility)
+	// NOTE: Go's flag.Parse stops at the first non-flag argument, so config
+	// flags (e.g. --api-url) placed *after* a positional command won't be
+	// parsed.  Users should prefer the --command form for full flag support.
 	if flag.NArg() > 0 {
 		cmd := flag.Arg(0)
 		switch cmd {

--- a/main.go
+++ b/main.go
@@ -42,17 +42,32 @@ func showHelp() {
 	fmt.Println("NannyAgent - AI-Powered Linux Diagnostic Agent")
 	fmt.Printf("Version: %s\n\n", Version)
 	fmt.Println("USAGE:")
-	fmt.Printf("  %s [COMMAND]\n\n", os.Args[0])
+	fmt.Printf("  %s [COMMAND] [OPTIONS]\n\n", os.Args[0])
 	fmt.Println("COMMANDS:")
-	fmt.Println("  --register           Register agent with NannyAI")
-	fmt.Println("  --status             Show agent status")
-	fmt.Println("  --diagnose <issue>   Run one-off diagnosis")
-	fmt.Println("  --daemon             Run as daemon (systemd)")
-	fmt.Println("  --version            Show version")
-	fmt.Println("  --help               Show this help")
+	fmt.Println("  --register                  Register agent with NannyAI")
+	fmt.Println("  --status                    Show agent status")
+	fmt.Println("  --diagnose <issue>          Run one-off diagnosis")
+	fmt.Println("  --daemon                    Run as daemon (systemd)")
+	fmt.Println("  --version                   Show version")
+	fmt.Println("  --help                      Show this help")
+	fmt.Println()
+	fmt.Println("CONFIG OVERRIDES (higher priority than config.yaml):")
+	fmt.Println("  --api-url <url>             NannyAPI endpoint URL")
+	fmt.Println("  --portal-url <url>          Portal URL for device authorization")
+	fmt.Println("  --token-path <path>         Token storage path")
+	fmt.Println("  --metrics-interval <secs>   Metrics collection interval")
+	fmt.Println("  --proxmox-interval <secs>   Proxmox data collection interval")
+	fmt.Println("  --agent-id <id>             Agent ID (for static token mode)")
+	fmt.Println("  --debug                     Enable debug mode")
+	fmt.Println()
+	fmt.Println("AUTHENTICATION:")
+	fmt.Println("  OAuth2 (default):   Register interactively with --register")
+	fmt.Println("  Static token:       Set static_token in /etc/nannyagent/config.yaml")
+	fmt.Println("                      Then run --register to auto-register")
 	fmt.Println()
 	fmt.Println("EXAMPLES:")
 	fmt.Println("  sudo nannyagent --register")
+	fmt.Println("  sudo nannyagent --register --api-url http://localhost:8090")
 	fmt.Println("  nannyagent --status")
 	fmt.Println("  sudo nannyagent --diagnose \"postgresql is slow\"")
 	fmt.Println("  sudo nannyagent    # Interactive mode")
@@ -139,7 +154,9 @@ func validateDiagnosisPrompt(prompt string) error {
 }
 
 // testAPIConnectivity tests if we can reach the API endpoint using NannyAPI
-func testAPIConnectivity(cfg *config.Config, authManager *auth.AuthManager, agentID string) error {
+func testAPIConnectivity(cfg *config.Config, authManager interface {
+	AuthenticatedRequest(method, url string, body []byte, headers map[string]string) (int, []byte, error)
+}, agentID string) error {
 	// Test by sending metrics to NannyAPI /api/agent endpoint
 	metricsCollector := metrics.NewCollector(Version, cfg.APIBaseURL)
 	systemMetrics, err := metricsCollector.GatherSystemMetrics()
@@ -168,7 +185,7 @@ func checkExistingAgentInstance() error {
 }
 
 // runRegisterCommand handles agent registration with NannyAPI device flow
-func runRegisterCommand() {
+func runRegisterCommand(cliFlags *config.CLIFlags) {
 	logging.Info("Starting NannyAgent registration with NannyAPI")
 
 	// Check if agent is already registered on this machine
@@ -188,20 +205,110 @@ func runRegisterCommand() {
 		cfg.APIBaseURL = os.Getenv("NANNYAPI_URL")
 	}
 
+	// Apply CLI flags (highest priority)
+	cfg.ApplyCLIFlags(cliFlags)
+
 	// Ensure we have a NannyAPI URL
 	if cfg.APIBaseURL == "" {
 		logging.Error("NannyAPI URL not configured")
-		logging.Error("Set NANNYAPI_URL environment variable or configure in /etc/nannyagent/config.yaml")
+		logging.Error("Set NANNYAPI_URL environment variable, configure in /etc/nannyagent/config.yaml,")
+		logging.Error("or pass --api-url <url>")
 		os.Exit(1)
 	}
 
 	// Ensure token path uses hardcoded DataDir
 	cfg.TokenPath = filepath.Join(DataDir, "token.json")
 
+	// ── Static token registration (fully automated, no user interaction) ────
+	if cfg.UseStaticToken() {
+		runStaticTokenRegister(cfg)
+		return
+	}
+
+	// ── OAuth2 device flow registration (interactive) ──────────────────────
+	runOAuthRegister(cfg)
+}
+
+// runStaticTokenRegister performs automated registration using a static token.
+// It starts device auth, auto-authorizes via the static token, and registers.
+func runStaticTokenRegister(cfg *config.Config) {
+	logging.Info("Using static token for automated registration")
+
+	staticAuth := auth.NewStaticTokenAuthManager(cfg)
+
+	// Step 1: Start device authorization (anonymous, no auth needed)
+	oauthMgr := auth.NewAuthManager(cfg)
+	deviceAuth, err := oauthMgr.StartDeviceAuthorization()
+	if err != nil {
+		logging.Error("Failed to start device authorization: %v", err)
+		os.Exit(1)
+	}
+
+	logging.Info("Device code obtained, auto-authorizing with static token...")
+
+	// Step 2: Auto-authorize the device code using the static token.
+	// The static token acts as the user, so we can approve the device code.
+	authorizePayload := fmt.Sprintf(`{"action":"authorize","user_code":"%s"}`, deviceAuth.UserCode)
+	statusCode, body, err := staticAuth.AuthenticatedRequest(
+		"POST",
+		fmt.Sprintf("%s/api/agent", cfg.APIBaseURL),
+		[]byte(authorizePayload),
+		nil,
+	)
+	if err != nil {
+		logging.Error("Failed to auto-authorize device code: %v", err)
+		os.Exit(1)
+	}
+	if statusCode != 200 {
+		logging.Error("Auto-authorize failed (status %d): %s", statusCode, string(body))
+		os.Exit(1)
+	}
+
+	logging.Info("Device code authorized automatically")
+
+	// Step 3: Register the agent (uses device_code, anonymous)
+	tokenResp, err := oauthMgr.PollForTokenAfterAuthorization(deviceAuth.DeviceCode)
+	if err != nil {
+		logging.Error("Registration failed: %v", err)
+		os.Exit(1)
+	}
+
+	// Step 4: Save agent_id to config (discard OAuth tokens since we use static token)
+	logging.Info("Registration successful!")
+	logging.Info("Agent ID: %s", tokenResp.AgentID)
+
+	if err := cfg.SaveAgentID(tokenResp.AgentID); err != nil {
+		logging.Warning("Could not save agent_id to config file: %v", err)
+		logging.Info("Please add manually: agent_id: \"%s\" to /etc/nannyagent/config.yaml", tokenResp.AgentID)
+	} else {
+		logging.Info("Agent ID saved to /etc/nannyagent/config.yaml")
+	}
+
+	// Also save the token file so that checkExistingAgentInstance works and
+	// --status can read the agent_id. We save it with just the agent_id.
+	token := &types.AuthToken{
+		AgentID:   tokenResp.AgentID,
+		TokenType: "static",
+		ExpiresAt: time.Now().Add(100 * 365 * 24 * time.Hour), // effectively never
+	}
+
+	authMgr := auth.NewAuthManager(cfg)
+	if err := authMgr.SaveToken(token); err != nil {
+		logging.Warning("Failed to save token marker file: %v", err)
+	}
+
+	logging.Info("")
+	logging.Info("Next steps:")
+	logging.Info("  1. Enable and start the service: sudo systemctl enable --now nannyagent")
+	logging.Info("  2. Check status: nannyagent --status")
+	logging.Info("  3. View logs: sudo journalctl -u nannyagent -f")
+	os.Exit(0)
+}
+
+// runOAuthRegister performs the interactive OAuth2 device flow registration.
+func runOAuthRegister(cfg *config.Config) {
 	// Initialize auth manager with NannyAPI URL
 	authManager := auth.NewAuthManager(cfg)
-
-	// Collect system information for registration (used later in register request)
 
 	// Step 1: Start device authorization
 	logging.Info("Initiating NannyAPI device authorization flow...")
@@ -257,7 +364,7 @@ func runRegisterCommand() {
 }
 
 // runStatusCommand shows agent connectivity and status with NannyAPI (stdout only)
-func runStatusCommand() {
+func runStatusCommand(cliFlags *config.CLIFlags) {
 	// Disable syslog for status command - everything goes to stdout only
 	logging.DisableSyslogOnly()
 
@@ -268,12 +375,22 @@ func runStatusCommand() {
 		os.Exit(1)
 	}
 
+	// Apply CLI flags
+	cfg.ApplyCLIFlags(cliFlags)
+
 	// Show API endpoint
 	apiURL := cfg.APIBaseURL
 	if apiURL == "" {
 		apiURL = os.Getenv("NANNYAPI_URL")
 	}
 	fmt.Printf("API Endpoint: %s\n", apiURL)
+
+	// Show auth mode
+	if cfg.UseStaticToken() {
+		fmt.Println("Auth Mode: Static Token")
+	} else {
+		fmt.Println("Auth Mode: OAuth2")
+	}
 
 	// Check if token exists
 	tokenPath := filepath.Join(DataDir, "token.json")
@@ -283,35 +400,62 @@ func runStatusCommand() {
 		os.Exit(1)
 	}
 
-	// Load and refresh token if needed
-	authManager := auth.NewAuthManager(cfg)
-	_, err = authManager.EnsureAuthenticated()
-	if err != nil {
-		fmt.Println("Authentication failed")
-		os.Exit(1)
-	}
+	if cfg.UseStaticToken() {
+		// Static token mode: get agent ID from config or token file
+		agentID := cfg.AgentID
+		if agentID == "" {
+			authManager := auth.NewAuthManager(cfg)
+			agentID, err = authManager.GetCurrentAgentID()
+			if err != nil {
+				fmt.Println("Failed to get Agent ID")
+				os.Exit(1)
+			}
+		}
+		fmt.Printf("Agent ID: %s\n", agentID)
 
-	// Get Agent ID
-	agentID, err := authManager.GetCurrentAgentID()
-	if err != nil {
-		fmt.Println("Failed to get Agent ID")
-		os.Exit(1)
-	}
+		// Test connectivity
+		staticAuth := auth.NewStaticTokenAuthManager(cfg)
+		if agentID != "" {
+			staticAuth.SetAgentID(agentID)
+		}
+		metricsCollector := metrics.NewCollector(Version, cfg.APIBaseURL)
+		systemMetrics, err := metricsCollector.GatherSystemMetrics()
+		if err != nil {
+			fmt.Println("Failed to gather metrics")
+			os.Exit(1)
+		}
+		err = metricsCollector.IngestMetrics(agentID, staticAuth, systemMetrics)
+		if err != nil {
+			fmt.Println("Metrics ingestion failed")
+			os.Exit(1)
+		}
+	} else {
+		// OAuth mode
+		authManager := auth.NewAuthManager(cfg)
+		_, err = authManager.EnsureAuthenticated()
+		if err != nil {
+			fmt.Println("Authentication failed")
+			os.Exit(1)
+		}
 
-	fmt.Printf("Agent ID: %s\n", agentID)
+		agentID, err := authManager.GetCurrentAgentID()
+		if err != nil {
+			fmt.Println("Failed to get Agent ID")
+			os.Exit(1)
+		}
+		fmt.Printf("Agent ID: %s\n", agentID)
 
-	// Test connectivity by sending metrics to backend API
-	metricsCollector := metrics.NewCollector(Version, cfg.APIBaseURL)
-	systemMetrics, err := metricsCollector.GatherSystemMetrics()
-	if err != nil {
-		fmt.Println("Failed to gather metrics")
-		os.Exit(1)
-	}
-
-	err = metricsCollector.IngestMetrics(agentID, authManager, systemMetrics)
-	if err != nil {
-		fmt.Println("Metrics ingestion failed")
-		os.Exit(1)
+		metricsCollector := metrics.NewCollector(Version, cfg.APIBaseURL)
+		systemMetrics, err := metricsCollector.GatherSystemMetrics()
+		if err != nil {
+			fmt.Println("Failed to gather metrics")
+			os.Exit(1)
+		}
+		err = metricsCollector.IngestMetrics(agentID, authManager, systemMetrics)
+		if err != nil {
+			fmt.Println("Metrics ingestion failed")
+			os.Exit(1)
+		}
 	}
 	if _, err := exec.LookPath("systemctl"); err == nil {
 		cmd := exec.Command("systemctl", "is-active", "nannyagent")
@@ -391,60 +535,51 @@ func runInteractiveDiagnostics(diagAgent *agent.LinuxDiagnosticAgent) {
 }
 
 func main() {
-	// Define flags (all with -- prefix for uniformity)
-	versionFlag := flag.Bool("version", false, "Show version information")
-	helpFlag := flag.Bool("help", false, "Show help information")
-	registerFlag := flag.Bool("register", false, "Register agent with NannyAI backend")
-	statusFlag := flag.Bool("status", false, "Show agent status and connectivity")
-	diagnoseFlag := flag.String("diagnose", "", "Run one-off diagnosis (e.g., --diagnose \"postgresql is slow\")")
-	daemonFlag := flag.Bool("daemon", false, "Run as daemon (systemd mode)")
-	flag.Parse()
+	// Parse CLI flags (all config options available as --flag)
+	cliFlags := config.ParseCLIFlags()
 
 	// Also check for commands without -- prefix (for backward compatibility)
-	// But log a warning to use -- prefix
 	if flag.NArg() > 0 {
 		cmd := flag.Arg(0)
 		switch cmd {
 		case "register":
 			logging.Warning("Please use: nannyagent --register (with -- prefix)")
-			*registerFlag = true
+			cliFlags.Register = true
 		case "status":
 			logging.Warning("Please use: nannyagent --status (with -- prefix)")
-			*statusFlag = true
+			cliFlags.Status = true
 		case "diagnose":
 			logging.Warning("Please use: nannyagent --diagnose (with -- prefix)")
 			if flag.NArg() > 1 {
-				*diagnoseFlag = flag.Arg(1)
-			} else {
-				*diagnoseFlag = ""
+				cliFlags.Diagnose = flag.Arg(1)
 			}
 		case "daemon":
 			logging.Warning("Please use: nannyagent --daemon (with -- prefix)")
-			*daemonFlag = true
+			cliFlags.Daemon = true
 		}
 	}
 
 	// Whitelist: commands that don't require root or auth
 	// Handle --version flag (no root required)
-	if *versionFlag {
+	if cliFlags.Version {
 		showVersion()
 	}
 
 	// Handle --help flag (no root required)
-	if *helpFlag {
+	if cliFlags.Help {
 		showHelp()
 	}
 
 	// Handle --status flag (no root or auth required) - EXIT IMMEDIATELY
-	if *statusFlag {
-		runStatusCommand()
+	if cliFlags.Status {
+		runStatusCommand(cliFlags)
 		return
 	}
 
 	// Handle --register flag (requires root, no auth needed) - EXIT IMMEDIATELY
-	if *registerFlag {
+	if cliFlags.Register {
 		checkRootPrivileges()
-		runRegisterCommand()
+		runRegisterCommand(cliFlags)
 		return
 	}
 
@@ -464,13 +599,157 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Apply CLI flags (highest priority)
+	cfg.ApplyCLIFlags(cliFlags)
+
 	cfg.PrintConfig()
 
+	// ── Branch on authentication mode ──────────────────────────────────────
+	if cfg.UseStaticToken() {
+		runWithStaticToken(cfg, cliFlags)
+	} else {
+		runWithOAuth(cfg, cliFlags)
+	}
+}
+
+// runWithStaticToken runs the agent using a static API token.
+// No OAuth token refresh or renewal goroutines are started.
+func runWithStaticToken(cfg *config.Config, cliFlags *config.CLIFlags) {
+	staticAuth := auth.NewStaticTokenAuthManager(cfg)
+
+	// Verify we have an agent ID
+	agentID, err := staticAuth.GetCurrentAgentID()
+	if err != nil {
+		// Try loading from token file as fallback
+		oauthMgr := auth.NewAuthManager(cfg)
+		agentID, err = oauthMgr.GetCurrentAgentID()
+		if err != nil {
+			logging.Error("Agent ID not found. Register first: sudo nannyagent --register")
+			os.Exit(1)
+		}
+		staticAuth.SetAgentID(agentID)
+	}
+
+	// Verify static token works
+	if err := staticAuth.EnsureAuthenticated(); err != nil {
+		logging.Error("Static token authentication failed: %v", err)
+		os.Exit(1)
+	}
+
+	// Test API connectivity
+	logging.Info("Testing connectivity to NannyAPI with static token...")
+	if err := testAPIConnectivity(cfg, staticAuth, agentID); err != nil {
+		logging.Error("Cannot connect to NannyAPI API: %v", err)
+		logging.Error("Endpoint: %s", cfg.APIBaseURL)
+		os.Exit(1)
+	}
+	logging.Info("API connectivity OK (static token mode)")
+
+	// Initialize the diagnostic agent
+	diagAgent := agent.NewLinuxDiagnosticAgentWithAuth(staticAuth, cfg.APIBaseURL)
+
+	// Handle --diagnose flag
+	if cliFlags.Diagnose != "" {
+		logging.Info("Running one-off diagnosis...")
+		if err := validateDiagnosisPrompt(cliFlags.Diagnose); err != nil {
+			logging.Error("%v", err)
+			os.Exit(1)
+		}
+		if err := diagAgent.DiagnoseIssue(cliFlags.Diagnose); err != nil {
+			logging.Error("Diagnosis failed: %v", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// Start SSE connection
+	go func() {
+		investigationHandler := func(id, prompt string) {
+			prompt = strings.TrimSpace(prompt)
+			investigationAgent := agent.NewLinuxDiagnosticAgentWithAuth(staticAuth, cfg.APIBaseURL)
+			investigationAgent.SetInvestigationID(id)
+			if err := investigationAgent.DiagnoseIssueWithInvestigation(prompt); err != nil {
+				logging.Error("Investigation %s failed: %v", id, err)
+			} else {
+				logging.Info("Investigation %s completed successfully", id)
+			}
+		}
+
+		patchHandler := func(payload types.AgentPatchPayload) {
+			logging.Info("Triggering patch operation %s (mode: %s)...", payload.OperationID, payload.Mode)
+			patchManager := patches.NewPatchManager(cfg.APIBaseURL, staticAuth, agentID)
+			if err := patchManager.HandlePatchOperation(payload); err != nil {
+				logging.Error("Patch operation %s failed: %v", payload.OperationID, err)
+			}
+		}
+
+		rebootHandler := func(payload types.AgentRebootPayload) {
+			logging.Info("Triggering reboot operation %s...", payload.RebootID)
+			rebootManager := reboot.NewRebootManager(cfg.APIBaseURL, staticAuth)
+			if err := rebootManager.HandleRebootOperation(payload); err != nil {
+				logging.Error("Reboot operation %s failed: %v", payload.RebootID, err)
+			}
+		}
+
+		realtimeClient := realtime.NewClient(cfg.APIBaseURL, staticAuth, investigationHandler, patchHandler, rebootHandler)
+		realtimeClient.Start()
+	}()
+
+	// Start metrics ingestion
+	go func() {
+		logging.Info("Starting metrics ingestion (interval: %ds, static token)...", cfg.MetricsInterval)
+		metricsCollector := metrics.NewCollector(Version, cfg.APIBaseURL)
+		ticker := time.NewTicker(time.Duration(cfg.MetricsInterval) * time.Second)
+		defer ticker.Stop()
+
+		systemMetrics, err := metricsCollector.GatherSystemMetrics()
+		if err == nil {
+			if err := metricsCollector.IngestMetrics(agentID, staticAuth, systemMetrics); err != nil {
+				logging.Error("Failed to ingest initial metrics: %v", err)
+			}
+		}
+
+		for range ticker.C {
+			systemMetrics, err := metricsCollector.GatherSystemMetrics()
+			if err != nil {
+				logging.Error("Failed to gather metrics: %v", err)
+				continue
+			}
+			if err := metricsCollector.IngestMetrics(agentID, staticAuth, systemMetrics); err != nil {
+				logging.Error("Failed to ingest metrics: %v", err)
+			}
+		}
+	}()
+
+	// No token renewal goroutine needed for static tokens
+
+	// Start Proxmox collector
+	proxmoxManager := proxmox.NewManager(cfg, staticAuth)
+	proxmoxManager.Start()
+
+	// Check if running in daemon mode
+	if cliFlags.Daemon {
+		if err := logging.EnableSyslogOnly(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to initialize syslog: %v\n", err)
+			os.Exit(1)
+		}
+		logging.Info("Running in daemon mode (static token, no interactive session)")
+		select {}
+	}
+
+	// Interactive mode
+	if !cliFlags.Daemon {
+		runInteractiveDiagnostics(diagAgent)
+	}
+}
+
+// runWithOAuth runs the agent using the traditional OAuth2 device flow.
+func runWithOAuth(cfg *config.Config, cliFlags *config.CLIFlags) {
 	// Initialize components
 	authManager := auth.NewAuthManager(cfg)
 
 	// Ensure authentication
-	_, err = authManager.EnsureAuthenticated()
+	_, err := authManager.EnsureAuthenticated()
 	if err != nil {
 		logging.Error("Authentication failed: %v", err)
 		os.Exit(1)
@@ -502,17 +781,17 @@ func main() {
 	diagAgent := agent.NewLinuxDiagnosticAgentWithAuth(authManager, cfg.APIBaseURL)
 
 	// Handle --diagnose flag (one-off diagnosis)
-	if *diagnoseFlag != "" {
+	if cliFlags.Diagnose != "" {
 		logging.Info("Running one-off diagnosis...")
 
 		// Validate the diagnosis prompt
-		if err := validateDiagnosisPrompt(*diagnoseFlag); err != nil {
+		if err := validateDiagnosisPrompt(cliFlags.Diagnose); err != nil {
 			logging.Error("%v", err)
 			logging.Info("Example: sudo nannyagent --diagnose \"postgresql is slow and using high CPU\"")
 			os.Exit(1)
 		}
 
-		if err := diagAgent.DiagnoseIssue(*diagnoseFlag); err != nil {
+		if err := diagAgent.DiagnoseIssue(cliFlags.Diagnose); err != nil {
 			logging.Error("Diagnosis failed: %v", err)
 			os.Exit(1)
 		}
@@ -521,14 +800,10 @@ func main() {
 
 	// Start SSE connection in a separate goroutine
 	go func() {
-		// Define the handler for investigations
 		investigationHandler := func(id, prompt string) {
 			prompt = strings.TrimSpace(prompt)
-
-			// Create a new agent instance for this investigation to ensure isolation
 			investigationAgent := agent.NewLinuxDiagnosticAgentWithAuth(authManager, cfg.APIBaseURL)
 			investigationAgent.SetInvestigationID(id)
-
 			if err := investigationAgent.DiagnoseIssueWithInvestigation(prompt); err != nil {
 				logging.Error("Investigation %s failed: %v", id, err)
 			} else {
@@ -536,13 +811,9 @@ func main() {
 			}
 		}
 
-		// Define the handler for patch operations
 		patchHandler := func(payload types.AgentPatchPayload) {
 			logging.Info("Triggering patch operation %s (mode: %s)...", payload.OperationID, payload.Mode)
-
-			// Create patch manager
 			patchManager := patches.NewPatchManager(cfg.APIBaseURL, authManager, agentID)
-
 			if err := patchManager.HandlePatchOperation(payload); err != nil {
 				logging.Error("Patch operation %s failed: %v", payload.OperationID, err)
 			} else {
@@ -550,13 +821,9 @@ func main() {
 			}
 		}
 
-		// Define the handler for reboot operations
 		rebootHandler := func(payload types.AgentRebootPayload) {
 			logging.Info("Triggering reboot operation %s...", payload.RebootID)
-
-			// Create reboot manager
 			rebootManager := reboot.NewRebootManager(cfg.APIBaseURL, authManager)
-
 			if err := rebootManager.HandleRebootOperation(payload); err != nil {
 				logging.Error("Reboot operation %s failed: %v", payload.RebootID, err)
 			} else {
@@ -564,10 +831,7 @@ func main() {
 			}
 		}
 
-		// Create and start the realtime client
-		// Use NANNYAPI_URL from env or default
-		pbURL := cfg.APIBaseURL
-		realtimeClient := realtime.NewClient(pbURL, authManager, investigationHandler, patchHandler, rebootHandler)
+		realtimeClient := realtime.NewClient(cfg.APIBaseURL, authManager, investigationHandler, patchHandler, rebootHandler)
 		realtimeClient.Start()
 	}()
 
@@ -578,7 +842,6 @@ func main() {
 		ticker := time.NewTicker(time.Duration(cfg.MetricsInterval) * time.Second)
 		defer ticker.Stop()
 
-		// Ingest immediately on start
 		systemMetrics, err := metricsCollector.GatherSystemMetrics()
 		if err == nil {
 			if err := metricsCollector.IngestMetrics(agentID, authManager, systemMetrics); err != nil {
@@ -592,18 +855,13 @@ func main() {
 				logging.Error("Failed to gather metrics: %v", err)
 				continue
 			}
-
 			if err := metricsCollector.IngestMetrics(agentID, authManager, systemMetrics); err != nil {
 				logging.Error("Failed to ingest metrics: %v", err)
 			}
 		}
 	}()
 
-	// Start background refresh token renewal goroutine.
-	// Checks every token_renewal_check_interval_secs seconds whether the refresh token
-	// is within the renewal threshold. Only calls renew-refresh-token when needed.
-	// If renewal fails (e.g., API unreachable), retries every token_renewal_retry_interval_secs
-	// seconds until it succeeds, then resumes the normal check cycle.
+	// Start background refresh token renewal goroutine (OAuth only)
 	go func() {
 		normalCheckInterval := time.Duration(cfg.TokenRenewalCheckIntervalSecs) * time.Second
 		retryInterval := time.Duration(cfg.TokenRenewalRetryIntervalSecs) * time.Second
@@ -627,7 +885,6 @@ func main() {
 				continue
 			}
 
-			// Get current refresh_token_expires_in via a standard refresh call
 			refreshResp, err := authManager.RefreshAccessToken(token.RefreshToken)
 			if err != nil {
 				logging.Warning("Token renewal check: refresh call failed: %v", err)
@@ -635,10 +892,9 @@ func main() {
 				continue
 			}
 
-			// Update the access token with the fresh one from the refresh call
 			updatedToken := &types.AuthToken{
 				AccessToken:  refreshResp.AccessToken,
-				RefreshToken: token.RefreshToken, // unchanged — refresh doesn't rotate it
+				RefreshToken: token.RefreshToken,
 				TokenType:    refreshResp.TokenType,
 				ExpiresAt:    time.Now().Add(time.Duration(refreshResp.ExpiresIn) * time.Second),
 				AgentID:      token.AgentID,
@@ -648,12 +904,10 @@ func main() {
 			}
 
 			if !auth.NeedsRefreshTokenRenewal(refreshResp.RefreshTokenExpiresIn, cfg.TokenRenewalThresholdDays) {
-				// Not within the renewal window yet — schedule normal check
 				nextCheck = time.Now().Add(normalCheckInterval)
 				continue
 			}
 
-			// Within renewal window: attempt rotation
 			logging.Info("Refresh token expires in %ds (threshold: %d days) — renewing...",
 				refreshResp.RefreshTokenExpiresIn, cfg.TokenRenewalThresholdDays)
 			renewResp, err := authManager.RenewRefreshToken(token.RefreshToken)
@@ -686,8 +940,7 @@ func main() {
 	proxmoxManager.Start()
 
 	// Check if running in daemon mode
-	if *daemonFlag {
-		// Switch to syslog-only logging first to avoid duplicates
+	if cliFlags.Daemon {
 		if err := logging.EnableSyslogOnly(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to initialize syslog: %v\n", err)
 			os.Exit(1)
@@ -695,14 +948,11 @@ func main() {
 
 		logging.Info("Running in daemon mode (no interactive session)")
 		logging.Info("Logs will be sent to syslog. View with: journalctl -u nannyagent -f")
-
-		// Block forever, let background goroutines handle everything
 		select {}
 	}
 
 	// Handle interactive mode (default if no flags)
-	if !*daemonFlag {
+	if !cliFlags.Daemon {
 		runInteractiveDiagnostics(diagAgent)
-		return
 	}
 }

--- a/main.go
+++ b/main.go
@@ -208,6 +208,12 @@ func runRegisterCommand(cliFlags *config.CLIFlags) {
 	// Apply CLI flags (highest priority)
 	cfg.ApplyCLIFlags(cliFlags)
 
+	// Re-validate after CLI overrides
+	if err := cfg.ValidateAfterMerge(); err != nil {
+		logging.Error("Invalid configuration: %v", err)
+		os.Exit(1)
+	}
+
 	// Ensure we have a NannyAPI URL
 	if cfg.APIBaseURL == "" {
 		logging.Error("NannyAPI URL not configured")
@@ -230,64 +236,32 @@ func runRegisterCommand(cliFlags *config.CLIFlags) {
 }
 
 // runStaticTokenRegister performs automated registration using a static token.
-// It starts device auth, auto-authorizes via the static token, and registers.
+// It sends a single POST /api/agent with the static token — no device auth flow.
 func runStaticTokenRegister(cfg *config.Config) {
-	logging.Info("Using static token for automated registration")
+	logging.Info("Using static token for direct registration (no device auth)")
 
 	staticAuth := auth.NewStaticTokenAuthManager(cfg)
 
-	// Step 1: Start device authorization (anonymous, no auth needed)
-	oauthMgr := auth.NewAuthManager(cfg)
-	deviceAuth, err := oauthMgr.StartDeviceAuthorization()
-	if err != nil {
-		logging.Error("Failed to start device authorization: %v", err)
-		os.Exit(1)
-	}
-
-	logging.Info("Device code obtained, auto-authorizing with static token...")
-
-	// Step 2: Auto-authorize the device code using the static token.
-	// The static token acts as the user, so we can approve the device code.
-	authorizePayload := fmt.Sprintf(`{"action":"authorize","user_code":"%s"}`, deviceAuth.UserCode)
-	statusCode, body, err := staticAuth.AuthenticatedRequest(
-		"POST",
-		fmt.Sprintf("%s/api/agent", cfg.APIBaseURL),
-		[]byte(authorizePayload),
-		nil,
-	)
-	if err != nil {
-		logging.Error("Failed to auto-authorize device code: %v", err)
-		os.Exit(1)
-	}
-	if statusCode != 200 {
-		logging.Error("Auto-authorize failed (status %d): %s", statusCode, string(body))
-		os.Exit(1)
-	}
-
-	logging.Info("Device code authorized automatically")
-
-	// Step 3: Register the agent (uses device_code, anonymous)
-	tokenResp, err := oauthMgr.PollForTokenAfterAuthorization(deviceAuth.DeviceCode)
+	resp, err := staticAuth.Register(Version)
 	if err != nil {
 		logging.Error("Registration failed: %v", err)
 		os.Exit(1)
 	}
 
-	// Step 4: Save agent_id to config (discard OAuth tokens since we use static token)
 	logging.Info("Registration successful!")
-	logging.Info("Agent ID: %s", tokenResp.AgentID)
+	logging.Info("Agent ID: %s", resp.AgentID)
 
-	if err := cfg.SaveAgentID(tokenResp.AgentID); err != nil {
+	if err := cfg.SaveAgentID(resp.AgentID); err != nil {
 		logging.Warning("Could not save agent_id to config file: %v", err)
-		logging.Info("Please add manually: agent_id: \"%s\" to /etc/nannyagent/config.yaml", tokenResp.AgentID)
+		logging.Info("Please add manually: agent_id: \"%s\" to /etc/nannyagent/config.yaml", resp.AgentID)
 	} else {
 		logging.Info("Agent ID saved to /etc/nannyagent/config.yaml")
 	}
 
-	// Also save the token file so that checkExistingAgentInstance works and
-	// --status can read the agent_id. We save it with just the agent_id.
+	// Save a token marker file so checkExistingAgentInstance recognizes
+	// the agent as registered and --status can read the agent_id.
 	token := &types.AuthToken{
-		AgentID:   tokenResp.AgentID,
+		AgentID:   resp.AgentID,
 		TokenType: "static",
 		ExpiresAt: time.Now().Add(100 * 365 * 24 * time.Hour), // effectively never
 	}
@@ -377,6 +351,12 @@ func runStatusCommand(cliFlags *config.CLIFlags) {
 
 	// Apply CLI flags
 	cfg.ApplyCLIFlags(cliFlags)
+
+	// Re-validate after CLI overrides
+	if err := cfg.ValidateAfterMerge(); err != nil {
+		fmt.Printf("Invalid configuration: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Show API endpoint
 	apiURL := cfg.APIBaseURL
@@ -601,6 +581,12 @@ func main() {
 
 	// Apply CLI flags (highest priority)
 	cfg.ApplyCLIFlags(cliFlags)
+
+	// Re-validate after CLI overrides
+	if err := cfg.ValidateAfterMerge(); err != nil {
+		logging.Error("Invalid configuration: %v", err)
+		os.Exit(1)
+	}
 
 	cfg.PrintConfig()
 


### PR DESCRIPTION
- Consume `register-with-token` action on API to support static tokens (completely bypasses OAuth device auth workflow)
- Add validations for yaml/cmd-line and env var configs at https://github.com/nannyagent/nannyagent/issues/52
- Support command line configs to register with specific API endpoints as requested by users at https://github.com/nannyagent/nannyagent/issues/47